### PR TITLE
ツイート詳細画面を作成(途中)

### DIFF
--- a/Tsuitta.xcodeproj/project.pbxproj
+++ b/Tsuitta.xcodeproj/project.pbxproj
@@ -16,6 +16,14 @@
 		0652FC781C1D77F2005006D3 /* ConstantColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0652FC771C1D77F2005006D3 /* ConstantColor.swift */; };
 		0652FC7A1C1D7C65005006D3 /* UIColor+hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0652FC791C1D7C65005006D3 /* UIColor+hex.swift */; };
 		065404691C38FA9000E97872 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 065404681C38FA9000E97872 /* TabBarController.swift */; };
+		2524D5861C54D2E600703B27 /* TweetDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2524D5851C54D2E600703B27 /* TweetDetailViewController.swift */; };
+		2524D5881C54D36200703B27 /* TweetDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2524D5871C54D36200703B27 /* TweetDetailView.swift */; };
+		2524D58A1C54D36D00703B27 /* TweetDetailView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2524D5891C54D36D00703B27 /* TweetDetailView.xib */; };
+		2524D58C1C54D65600703B27 /* MainTweetDetailTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2524D58B1C54D65600703B27 /* MainTweetDetailTableViewCell.xib */; };
+		2524D58E1C54D66700703B27 /* MainTweetDetailTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2524D58D1C54D66700703B27 /* MainTweetDetailTableViewCell.swift */; };
+		2524D5901C55027900703B27 /* MainTweetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2524D58F1C55027900703B27 /* MainTweetView.swift */; };
+		2524D5921C55029100703B27 /* MainTweetView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2524D5911C55029100703B27 /* MainTweetView.xib */; };
+		2524D5941C550D0700703B27 /* UIView+Constraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2524D5931C550D0700703B27 /* UIView+Constraint.swift */; };
 		253D5E871C148E6600D59DC0 /* icon.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 253D5E861C148E6600D59DC0 /* icon.jpg */; };
 		25590F991C391D660024CEC3 /* TimeLineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25590F981C391D660024CEC3 /* TimeLineViewController.swift */; };
 		25590F9D1C40F07B0024CEC3 /* APILocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25590F9C1C40F07B0024CEC3 /* APILocator.swift */; };
@@ -89,6 +97,14 @@
 		0652FC771C1D77F2005006D3 /* ConstantColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstantColor.swift; sourceTree = "<group>"; };
 		0652FC791C1D7C65005006D3 /* UIColor+hex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+hex.swift"; sourceTree = "<group>"; };
 		065404681C38FA9000E97872 /* TabBarController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
+		2524D5851C54D2E600703B27 /* TweetDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweetDetailViewController.swift; sourceTree = "<group>"; };
+		2524D5871C54D36200703B27 /* TweetDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweetDetailView.swift; sourceTree = "<group>"; };
+		2524D5891C54D36D00703B27 /* TweetDetailView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TweetDetailView.xib; sourceTree = "<group>"; };
+		2524D58B1C54D65600703B27 /* MainTweetDetailTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MainTweetDetailTableViewCell.xib; sourceTree = "<group>"; };
+		2524D58D1C54D66700703B27 /* MainTweetDetailTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainTweetDetailTableViewCell.swift; sourceTree = "<group>"; };
+		2524D58F1C55027900703B27 /* MainTweetView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainTweetView.swift; sourceTree = "<group>"; };
+		2524D5911C55029100703B27 /* MainTweetView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MainTweetView.xib; sourceTree = "<group>"; };
+		2524D5931C550D0700703B27 /* UIView+Constraint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Constraint.swift"; sourceTree = "<group>"; };
 		253D5E861C148E6600D59DC0 /* icon.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = icon.jpg; sourceTree = "<group>"; };
 		25590F981C391D660024CEC3 /* TimeLineViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeLineViewController.swift; sourceTree = "<group>"; };
 		25590F9C1C40F07B0024CEC3 /* APILocator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APILocator.swift; sourceTree = "<group>"; };
@@ -159,6 +175,7 @@
 			isa = PBXGroup;
 			children = (
 				0652FC791C1D7C65005006D3 /* UIColor+hex.swift */,
+				2524D5931C550D0700703B27 /* UIView+Constraint.swift */,
 			);
 			name = Extension;
 			sourceTree = "<group>";
@@ -256,6 +273,7 @@
 				257559501C12C39D0031B6CF /* PagingController.swift */,
 				065404681C38FA9000E97872 /* TabBarController.swift */,
 				0652FC6C1C1D5692005006D3 /* HomeViewController.swift */,
+				2524D5851C54D2E600703B27 /* TweetDetailViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -361,7 +379,7 @@
 			isa = PBXGroup;
 			children = (
 				259DD37E1C004D4300C9B7CE /* API */,
-				259DD37F1C004D4300C9B7CE /* UserData */,
+				259DD37F1C004D4300C9B7CE /* DataBase */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -380,10 +398,11 @@
 			path = API;
 			sourceTree = "<group>";
 		};
-		259DD37F1C004D4300C9B7CE /* UserData */ = {
+		259DD37F1C004D4300C9B7CE /* DataBase */ = {
 			isa = PBXGroup;
 			children = (
 			);
+			name = DataBase;
 			path = UserData;
 			sourceTree = "<group>";
 		};
@@ -475,6 +494,12 @@
 		259DD38A1C004D4300C9B7CE /* Tweet */ = {
 			isa = PBXGroup;
 			children = (
+				2524D5871C54D36200703B27 /* TweetDetailView.swift */,
+				2524D5891C54D36D00703B27 /* TweetDetailView.xib */,
+				2524D58D1C54D66700703B27 /* MainTweetDetailTableViewCell.swift */,
+				2524D58B1C54D65600703B27 /* MainTweetDetailTableViewCell.xib */,
+				2524D58F1C55027900703B27 /* MainTweetView.swift */,
+				2524D5911C55029100703B27 /* MainTweetView.xib */,
 			);
 			path = Tweet;
 			sourceTree = "<group>";
@@ -615,6 +640,9 @@
 				259DD33C1C00429B00C9B7CE /* Main.storyboard in Resources */,
 				253D5E871C148E6600D59DC0 /* icon.jpg in Resources */,
 				257559561C12E3250031B6CF /* LoginView.xib in Resources */,
+				2524D58A1C54D36D00703B27 /* TweetDetailView.xib in Resources */,
+				2524D58C1C54D65600703B27 /* MainTweetDetailTableViewCell.xib in Resources */,
+				2524D5921C55029100703B27 /* MainTweetView.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -666,12 +694,17 @@
 				257559541C12E3160031B6CF /* LoginView.swift in Sources */,
 				25D441DD1C2527F600C84D58 /* APIClient.swift in Sources */,
 				0652FC781C1D77F2005006D3 /* ConstantColor.swift in Sources */,
+				2524D5861C54D2E600703B27 /* TweetDetailViewController.swift in Sources */,
 				25590F9F1C4103650024CEC3 /* UserAPIManager.swift in Sources */,
+				2524D58E1C54D66700703B27 /* MainTweetDetailTableViewCell.swift in Sources */,
 				0652FC731C1D587B005006D3 /* HomeView.swift in Sources */,
+				2524D5901C55027900703B27 /* MainTweetView.swift in Sources */,
 				25590FA51C4103F10024CEC3 /* AuthAPIManager.swift in Sources */,
 				25590FA11C4103930024CEC3 /* TweetAPIManager.swift in Sources */,
 				25590FCD1C424D7F0024CEC3 /* SettingAPIManager.swift in Sources */,
+				2524D5881C54D36200703B27 /* TweetDetailView.swift in Sources */,
 				257559511C12C39D0031B6CF /* PagingController.swift in Sources */,
+				2524D5941C550D0700703B27 /* UIView+Constraint.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tsuitta/Controller/TweetDetailViewController.swift
+++ b/Tsuitta/Controller/TweetDetailViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import TwitterKit
 
+/// ツイート詳細画面のViewController
 class TweetDetailViewController: UIViewController {
     
     private var tweet: TWTRTweet!

--- a/Tsuitta/Controller/TweetDetailViewController.swift
+++ b/Tsuitta/Controller/TweetDetailViewController.swift
@@ -1,0 +1,27 @@
+import UIKit
+import TwitterKit
+
+class TweetDetailViewController: UIViewController {
+    
+    private var tweet: TWTRTweet!
+    
+    override func loadView() {
+        super.loadView()
+        
+        if let view = UINib(nibName: "TweetDetailView", bundle: nil).instantiateWithOwner(self, options: nil).first as? TweetDetailView {
+            self.view = view
+        }
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        APILocator.sharedInstance.tweet.single("678556859976933376", callback: { (tweet) -> Void in
+            guard let v = self.view as? TweetDetailView else {
+                return
+            }
+            v.reloadMainTweetData(tweet)
+            self.tweet = tweet
+        })
+    }
+}

--- a/Tsuitta/UIView+Constraint.swift
+++ b/Tsuitta/UIView+Constraint.swift
@@ -1,0 +1,46 @@
+import UIKit
+
+extension UIView {
+    /**
+     addSubViewした後に、Viewを親Viewと同じ大きさになるようにConstraintを設定する。
+     
+     - parameter view: addSubViewするView
+     */
+    //TODO: メソッド名ひどいので修正したい
+    func addSubviewWithFullConstraint(view: UIView) {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        self.addSubview(view)
+        
+        self.addConstraints(
+            [
+                createConstraint(view, attr: .Top),
+                createConstraint(view, attr: .Right),
+                createConstraint(view, attr: .Bottom),
+                createConstraint(view, attr: .Left)
+            ]
+        )
+    }
+    
+    /**
+     引数のViewとselfのattrをequal指定にしたconstraintを作成します。
+     TODO:↑ちょっと何言ってるかわからないね
+     
+     - parameter view: constraintを追加するView
+     - parameter attr: constraintを設定するattr
+     
+     - returns: constraint
+     */
+    // TODO: メソッド名修正したい
+    private func createConstraint(view: UIView, attr: NSLayoutAttribute) -> NSLayoutConstraint {
+        return NSLayoutConstraint(
+            item: self,
+            attribute: attr,
+            relatedBy: .Equal,
+            toItem: view,
+            attribute: attr,
+            multiplier: 1.0,
+            constant: 0
+        )
+    }
+}

--- a/Tsuitta/View/Tweet/MainTweetDetailTableViewCell.swift
+++ b/Tsuitta/View/Tweet/MainTweetDetailTableViewCell.swift
@@ -1,6 +1,7 @@
 import UIKit
 import TwitterKit
 
+/// ツイート詳細画面のメインのツイート部分のView
 class MainTweetDetailTableViewCell: UITableViewCell {
     
     private var mainTweetView: MainTweetView?

--- a/Tsuitta/View/Tweet/MainTweetDetailTableViewCell.swift
+++ b/Tsuitta/View/Tweet/MainTweetDetailTableViewCell.swift
@@ -1,0 +1,49 @@
+import UIKit
+import TwitterKit
+
+class MainTweetDetailTableViewCell: UITableViewCell {
+    
+    private var mainTweetView: MainTweetView?
+    
+    @IBOutlet weak private var RetweetView: UIView!
+    
+    @IBOutlet weak private var RetweetLabel: UILabel!
+    
+    @IBOutlet weak private var tweetView: UIView!{
+        didSet{
+            if let view = UINib(nibName: "MainTweetView", bundle: nil).instantiateWithOwner(self, options: nil).first as? MainTweetView {
+                self.mainTweetView = view
+                self.tweetView.addSubviewWithFullConstraint(view)
+            }
+        }
+    }
+    
+    @IBAction func didTapReplyButton(sender: UIButton) {
+        //TODO: Reply を実装するよ
+    }
+    
+    @IBAction func didTapRetweetButton(sender: UIButton) {
+        //TODO: Retweet を実装するよ
+    }
+    
+    @IBAction func didTapLikeButton(sender: UIButton) {
+        //TODO: Like を実装するよ
+    }
+    
+    @IBAction func didTapActionButton(sender: UIButton) {
+        //TODO: その他のアクションを実装するよ
+    }
+    
+    func setup(tweetData: TWTRTweet) {
+        guard let v = self.mainTweetView else {
+            return
+        }
+        v.setup(tweetData)
+    }
+    
+    private func setupRetweet() {
+        //TODO: Retweet していたらRetweetのやつ表示する
+    }
+    
+    
+}

--- a/Tsuitta/View/Tweet/MainTweetDetailTableViewCell.xib
+++ b/Tsuitta/View/Tweet/MainTweetDetailTableViewCell.xib
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="311" id="jOU-MR-zPb" customClass="MainTweetDetailTableViewCell" customModule="Tsuitta" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="380" height="311"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="infinite" tableViewCell="jOU-MR-zPb" id="Usu-i4-P01">
+                <rect key="frame" x="0.0" y="0.0" width="380" height="310.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vKY-45-f9V" userLabel="RetweetView">
+                        <rect key="frame" x="0.0" y="0.0" width="380" height="40"/>
+                        <subviews>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sample.jpg" translatesAutoresizingMaskIntoConstraints="NO" id="3Xm-KO-fIb">
+                                <rect key="frame" x="84.5" y="4" width="32" height="32"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="3Xm-KO-fIb" secondAttribute="height" multiplier="1:1" id="pl9-0c-RLv"/>
+                                </constraints>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="あいださんがリツイート" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tR2-UB-MrG">
+                                <rect key="frame" x="116.5" y="0.0" width="187" height="40"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="tR2-UB-MrG" secondAttribute="trailing" id="3EJ-uP-yQZ"/>
+                            <constraint firstAttribute="bottom" secondItem="tR2-UB-MrG" secondAttribute="bottom" id="DEr-Jm-Mrg"/>
+                            <constraint firstItem="3Xm-KO-fIb" firstAttribute="height" secondItem="vKY-45-f9V" secondAttribute="height" multiplier="0.8" id="Kgo-Uc-pi1"/>
+                            <constraint firstItem="tR2-UB-MrG" firstAttribute="leading" secondItem="3Xm-KO-fIb" secondAttribute="trailing" id="So8-aa-rMe"/>
+                            <constraint firstAttribute="height" constant="40" id="TYa-TT-PcK"/>
+                            <constraint firstAttribute="trailing" secondItem="tR2-UB-MrG" secondAttribute="trailing" id="b3U-xh-bxl"/>
+                            <constraint firstItem="tR2-UB-MrG" firstAttribute="centerX" secondItem="vKY-45-f9V" secondAttribute="centerX" constant="20" id="bVr-4Y-tkX"/>
+                            <constraint firstItem="tR2-UB-MrG" firstAttribute="top" secondItem="vKY-45-f9V" secondAttribute="top" id="d1G-uj-QbG"/>
+                            <constraint firstItem="3Xm-KO-fIb" firstAttribute="centerY" secondItem="vKY-45-f9V" secondAttribute="centerY" id="gCV-PW-9bC"/>
+                            <constraint firstItem="3Xm-KO-fIb" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="vKY-45-f9V" secondAttribute="leading" id="qAv-nb-RGj"/>
+                            <constraint firstItem="tR2-UB-MrG" firstAttribute="leading" secondItem="vKY-45-f9V" secondAttribute="leading" id="zko-Tz-eib"/>
+                        </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="b3U-xh-bxl"/>
+                                <exclude reference="zko-Tz-eib"/>
+                            </mask>
+                        </variation>
+                    </view>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fPk-k9-jsJ" userLabel="ActionView">
+                        <rect key="frame" x="0.0" y="258" width="380" height="52"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ib9-4x-UsQ">
+                                <rect key="frame" x="20" y="0.0" width="340" height="52"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MHA-6E-jn1" userLabel="ReplyButton">
+                                        <rect key="frame" x="0.0" y="0.0" width="85" height="52"/>
+                                        <state key="normal" image="icon.jpg"/>
+                                        <connections>
+                                            <action selector="didTapReplyButton:" destination="jOU-MR-zPb" eventType="touchUpInside" id="Q3r-Q5-CfJ"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E9M-h1-uJa" userLabel="ActionButton">
+                                        <rect key="frame" x="255" y="0.0" width="85" height="52"/>
+                                        <state key="normal" image="icon.jpg"/>
+                                        <connections>
+                                            <action selector="didTapActionButton:" destination="jOU-MR-zPb" eventType="touchUpInside" id="18a-gu-bHj"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ACq-8x-NuQ" userLabel="RetweetButton">
+                                        <rect key="frame" x="85" y="0.0" width="85" height="52"/>
+                                        <state key="normal" image="icon.jpg"/>
+                                        <connections>
+                                            <action selector="didTapRetweetButton:" destination="jOU-MR-zPb" eventType="touchUpInside" id="Rag-D2-QS4"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qsi-Js-fWa" userLabel="LiekButton">
+                                        <rect key="frame" x="170" y="0.0" width="85" height="52"/>
+                                        <state key="normal" image="icon.jpg"/>
+                                        <connections>
+                                            <action selector="didTapLikeButton:" destination="jOU-MR-zPb" eventType="touchUpInside" id="pg1-oN-XVo"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstItem="qsi-Js-fWa" firstAttribute="width" secondItem="MHA-6E-jn1" secondAttribute="width" id="5gM-oE-me6"/>
+                                    <constraint firstItem="ACq-8x-NuQ" firstAttribute="top" secondItem="Ib9-4x-UsQ" secondAttribute="top" id="5o3-eV-wgv"/>
+                                    <constraint firstAttribute="bottom" secondItem="E9M-h1-uJa" secondAttribute="bottom" id="7BP-A8-7bk"/>
+                                    <constraint firstItem="E9M-h1-uJa" firstAttribute="top" secondItem="Ib9-4x-UsQ" secondAttribute="top" id="E9k-Oz-auA"/>
+                                    <constraint firstItem="qsi-Js-fWa" firstAttribute="top" secondItem="Ib9-4x-UsQ" secondAttribute="top" id="FvY-f9-G62"/>
+                                    <constraint firstItem="MHA-6E-jn1" firstAttribute="top" secondItem="Ib9-4x-UsQ" secondAttribute="top" id="TkW-Ft-4jM"/>
+                                    <constraint firstItem="E9M-h1-uJa" firstAttribute="width" secondItem="MHA-6E-jn1" secondAttribute="width" id="Ukh-CF-5sk"/>
+                                    <constraint firstItem="ACq-8x-NuQ" firstAttribute="leading" secondItem="MHA-6E-jn1" secondAttribute="trailing" id="WOg-Gc-1Rc"/>
+                                    <constraint firstAttribute="bottom" secondItem="qsi-Js-fWa" secondAttribute="bottom" id="X8O-P1-qDk"/>
+                                    <constraint firstItem="ACq-8x-NuQ" firstAttribute="width" secondItem="MHA-6E-jn1" secondAttribute="width" id="bKx-at-nrz"/>
+                                    <constraint firstItem="qsi-Js-fWa" firstAttribute="leading" secondItem="ACq-8x-NuQ" secondAttribute="trailing" id="hMo-py-8Dj"/>
+                                    <constraint firstItem="MHA-6E-jn1" firstAttribute="leading" secondItem="Ib9-4x-UsQ" secondAttribute="leading" id="kL7-zT-ZN6"/>
+                                    <constraint firstAttribute="bottom" secondItem="MHA-6E-jn1" secondAttribute="bottom" id="lWF-ON-gwW"/>
+                                    <constraint firstItem="E9M-h1-uJa" firstAttribute="leading" secondItem="qsi-Js-fWa" secondAttribute="trailing" id="n27-Cf-LEG"/>
+                                    <constraint firstAttribute="trailing" secondItem="E9M-h1-uJa" secondAttribute="trailing" id="z1J-2X-Dog"/>
+                                    <constraint firstAttribute="bottom" secondItem="ACq-8x-NuQ" secondAttribute="bottom" id="zxx-Ce-auK"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="Ib9-4x-UsQ" firstAttribute="leading" secondItem="fPk-k9-jsJ" secondAttribute="leading" constant="20" id="7EB-DV-RZS"/>
+                            <constraint firstAttribute="bottom" secondItem="Ib9-4x-UsQ" secondAttribute="bottom" id="Rrt-y6-pSZ"/>
+                            <constraint firstAttribute="height" constant="52" id="Vcx-ae-Oez"/>
+                            <constraint firstItem="Ib9-4x-UsQ" firstAttribute="top" secondItem="fPk-k9-jsJ" secondAttribute="top" id="cWH-To-95n"/>
+                            <constraint firstAttribute="trailing" secondItem="Ib9-4x-UsQ" secondAttribute="trailing" constant="20" id="ztz-9J-Vjh"/>
+                        </constraints>
+                    </view>
+                    <view contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="infinite" translatesAutoresizingMaskIntoConstraints="NO" id="AAU-4j-xzI" userLabel="TweetView">
+                        <rect key="frame" x="0.0" y="40" width="380" height="218"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="fPk-k9-jsJ" secondAttribute="bottom" id="A2K-Ay-BjS"/>
+                    <constraint firstItem="vKY-45-f9V" firstAttribute="top" secondItem="Usu-i4-P01" secondAttribute="top" id="Fqz-MG-l5f"/>
+                    <constraint firstItem="AAU-4j-xzI" firstAttribute="leading" secondItem="Usu-i4-P01" secondAttribute="leading" id="K9Y-Xe-8KW"/>
+                    <constraint firstItem="AAU-4j-xzI" firstAttribute="top" secondItem="vKY-45-f9V" secondAttribute="bottom" id="Mtc-Sv-o6o"/>
+                    <constraint firstAttribute="trailing" secondItem="vKY-45-f9V" secondAttribute="trailing" id="P0o-oV-jlL"/>
+                    <constraint firstAttribute="trailing" secondItem="fPk-k9-jsJ" secondAttribute="trailing" id="Rcz-g3-JAR"/>
+                    <constraint firstItem="vKY-45-f9V" firstAttribute="leading" secondItem="Usu-i4-P01" secondAttribute="leading" id="TUj-6o-8um"/>
+                    <constraint firstAttribute="trailing" secondItem="AAU-4j-xzI" secondAttribute="trailing" id="Uyt-gl-HWN"/>
+                    <constraint firstItem="fPk-k9-jsJ" firstAttribute="top" secondItem="AAU-4j-xzI" secondAttribute="bottom" id="VUe-lK-vIP"/>
+                    <constraint firstItem="fPk-k9-jsJ" firstAttribute="leading" secondItem="Usu-i4-P01" secondAttribute="leading" id="sb7-TY-wu8"/>
+                    <constraint firstItem="vKY-45-f9V" firstAttribute="top" secondItem="Usu-i4-P01" secondAttribute="top" id="whR-sQ-QpA"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="RetweetLabel" destination="tR2-UB-MrG" id="7LK-4x-FRv"/>
+                <outlet property="RetweetView" destination="vKY-45-f9V" id="vPe-cZ-yGA"/>
+                <outlet property="tweetView" destination="AAU-4j-xzI" id="RM4-WI-NyR"/>
+            </connections>
+            <point key="canvasLocation" x="249" y="398.5"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <image name="icon.jpg" width="192" height="192"/>
+        <image name="sample.jpg" width="10" height="8"/>
+    </resources>
+</document>

--- a/Tsuitta/View/Tweet/MainTweetView.swift
+++ b/Tsuitta/View/Tweet/MainTweetView.swift
@@ -1,0 +1,48 @@
+import UIKit
+import TwitterKit
+
+class MainTweetView: UIView {
+    
+    @IBOutlet weak private var profileImageView: UIImageView!
+    
+    @IBOutlet weak private var screenNameLabel: UILabel!
+    
+    @IBOutlet weak private var nameLabel: UILabel!
+    
+    @IBOutlet weak private var contentLabel: UILabel!
+    
+    @IBOutlet weak private var contentImageAreaView: UIView!
+    
+    @IBOutlet weak private var dateLabel: UILabel!
+    
+    @IBOutlet weak private var retweetLabel: UILabel!
+    
+    @IBOutlet weak private var likeLabel: UILabel!
+    
+    private var tweetId: String!
+    
+    func setup(tweetData: TWTRTweet) {
+        self.tweetId = tweetData.tweetID
+        //TODO: deprecated なおそ！
+        let req = NSURLRequest(URL:NSURL(string: tweetData.author.profileImageURL)!)
+        NSURLConnection.sendAsynchronousRequest(req, queue:NSOperationQueue.mainQueue()){(res, data, err) in
+            self.profileImageView.image = UIImage(data:data!)
+        }
+        
+        self.screenNameLabel.text = tweetData.author.screenName
+        self.nameLabel.text = tweetData.author.name
+        self.contentLabel.text = tweetData.text
+        self.dateLabel.text = self.convertNSDateToString(tweetData.createdAt)
+        self.retweetLabel.text = String(tweetData.retweetCount) + "RT"
+        self.likeLabel.text = String(tweetData.likeCount) + "Like"
+    }
+    
+    
+    //TODO: 後で便利関数にまとめる
+    private func convertNSDateToString(date: NSDate) -> String {
+        let formatter = NSDateFormatter()
+        formatter.dateFormat = "YYYY-MM-dd hh:mm:ss"
+        
+        return formatter.stringFromDate(date)
+    }
+}

--- a/Tsuitta/View/Tweet/MainTweetView.swift
+++ b/Tsuitta/View/Tweet/MainTweetView.swift
@@ -1,6 +1,7 @@
 import UIKit
 import TwitterKit
 
+/// ツイート詳細画面のメインのツイートの一部。ツイートの内容を表示するView。特にActionはない。
 class MainTweetView: UIView {
     
     @IBOutlet weak private var profileImageView: UIImageView!

--- a/Tsuitta/View/Tweet/MainTweetView.xib
+++ b/Tsuitta/View/Tweet/MainTweetView.xib
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="MainTweetView" customModule="Tsuitta" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="339" height="302"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eYZ-my-eaS" userLabel="ProfileView">
+                    <rect key="frame" x="0.0" y="0.0" width="339" height="63"/>
+                    <subviews>
+                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sample.jpg" translatesAutoresizingMaskIntoConstraints="NO" id="y0U-fP-pEV" userLabel="IconImageView">
+                            <rect key="frame" x="10" y="0.0" width="63" height="63"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="y0U-fP-pEV" secondAttribute="height" multiplier="1:1" id="CFj-cu-Mae"/>
+                            </constraints>
+                        </imageView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="20.5" text="会社に見を捧げるミクbot" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="eLd-XX-deS" userLabel="ScreenNameLabel">
+                            <rect key="frame" x="81" y="0.0" width="248" height="20.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="infinite" text="@dorei_miku" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="shY-e9-mcG" userLabel="NameLabel">
+                            <rect key="frame" x="81" y="20" width="248" height="42.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                            <color key="textColor" red="0.57360716540404044" green="0.57360716540404044" blue="0.57360716540404044" alpha="1" colorSpace="calibratedRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstItem="eLd-XX-deS" firstAttribute="leading" secondItem="y0U-fP-pEV" secondAttribute="trailing" constant="8" id="4jj-dR-22Y"/>
+                        <constraint firstItem="shY-e9-mcG" firstAttribute="top" secondItem="eLd-XX-deS" secondAttribute="bottom" id="COX-el-HdD"/>
+                        <constraint firstItem="eLd-XX-deS" firstAttribute="top" secondItem="eYZ-my-eaS" secondAttribute="top" id="HBj-Zr-oyl"/>
+                        <constraint firstAttribute="bottom" secondItem="shY-e9-mcG" secondAttribute="bottom" id="LPE-gI-6cS"/>
+                        <constraint firstAttribute="height" constant="63" id="RnJ-VC-aWh"/>
+                        <constraint firstAttribute="trailing" secondItem="shY-e9-mcG" secondAttribute="trailing" constant="10" id="k0q-vF-hb4"/>
+                        <constraint firstItem="y0U-fP-pEV" firstAttribute="top" secondItem="eYZ-my-eaS" secondAttribute="top" id="lsm-SI-PXN"/>
+                        <constraint firstItem="y0U-fP-pEV" firstAttribute="leading" secondItem="eYZ-my-eaS" secondAttribute="leading" constant="10" id="qPT-42-Er1"/>
+                        <constraint firstItem="shY-e9-mcG" firstAttribute="leading" secondItem="y0U-fP-pEV" secondAttribute="trailing" constant="8" id="w1d-H7-YVC"/>
+                        <constraint firstAttribute="bottom" secondItem="y0U-fP-pEV" secondAttribute="bottom" id="wwi-ko-03c"/>
+                        <constraint firstAttribute="trailing" secondItem="eLd-XX-deS" secondAttribute="trailing" constant="10" id="zMh-zw-KGG"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cAr-hJ-nID" userLabel="DateView">
+                    <rect key="frame" x="0.0" y="252" width="339" height="25"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2016/01/26" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FEu-nk-6nc" userLabel="DateLabel">
+                            <rect key="frame" x="10" y="0.0" width="319" height="25"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                            <color key="textColor" red="0.49656723484848486" green="0.49656723484848486" blue="0.49656723484848486" alpha="1" colorSpace="calibratedRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstItem="FEu-nk-6nc" firstAttribute="top" secondItem="cAr-hJ-nID" secondAttribute="top" id="4dQ-DM-Rch"/>
+                        <constraint firstAttribute="trailing" secondItem="FEu-nk-6nc" secondAttribute="trailing" constant="10" id="Tvg-5B-Xij"/>
+                        <constraint firstItem="FEu-nk-6nc" firstAttribute="leading" secondItem="cAr-hJ-nID" secondAttribute="leading" constant="10" id="aAT-fX-4IL"/>
+                        <constraint firstAttribute="height" constant="25" id="cRl-XQ-Gos"/>
+                        <constraint firstAttribute="bottom" secondItem="FEu-nk-6nc" secondAttribute="bottom" id="vqs-Kd-fiS"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ke5-eo-y6p" userLabel="InfoView">
+                    <rect key="frame" x="0.0" y="277" width="339" height="25"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="600RT" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U8b-Uo-l2s" userLabel="RetweetLabel">
+                            <rect key="frame" x="10" y="0.0" width="38.5" height="25"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="24Fav" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CpS-ba-mZ3" userLabel="LikeLabel">
+                            <rect key="frame" x="68.5" y="0.0" width="34.5" height="25"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstAttribute="bottom" secondItem="U8b-Uo-l2s" secondAttribute="bottom" id="0PL-VM-Rlm"/>
+                        <constraint firstItem="U8b-Uo-l2s" firstAttribute="top" secondItem="Ke5-eo-y6p" secondAttribute="top" id="2Fw-YC-dAS"/>
+                        <constraint firstAttribute="bottom" secondItem="CpS-ba-mZ3" secondAttribute="bottom" id="Cgf-ol-Krs"/>
+                        <constraint firstItem="CpS-ba-mZ3" firstAttribute="top" secondItem="Ke5-eo-y6p" secondAttribute="top" id="GWo-1c-9Hg"/>
+                        <constraint firstItem="U8b-Uo-l2s" firstAttribute="leading" secondItem="Ke5-eo-y6p" secondAttribute="leading" constant="10" id="Tv1-eH-Eb7"/>
+                        <constraint firstAttribute="height" constant="25" id="aWA-b4-h79"/>
+                        <constraint firstItem="CpS-ba-mZ3" firstAttribute="leading" secondItem="U8b-Uo-l2s" secondAttribute="trailing" constant="20" id="hHf-n2-fai"/>
+                        <constraint firstAttribute="trailing" secondItem="U8b-Uo-l2s" secondAttribute="trailing" constant="10" id="kGs-3C-TNA"/>
+                    </constraints>
+                    <variation key="default">
+                        <mask key="constraints">
+                            <exclude reference="kGs-3C-TNA"/>
+                        </mask>
+                    </variation>
+                </view>
+                <view contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="infinite" translatesAutoresizingMaskIntoConstraints="NO" id="QHV-Wf-hde" userLabel="ContentsView">
+                    <rect key="frame" x="0.0" y="63" width="339" height="189"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="自分はまだ大丈夫と思っている人ほど大丈夫じゃなかったりするにゃ！一度壊れた心はそう簡単に元には戻らないにゃ。取り返しがつかなくなる前にそんな会社やめちまえにゃ！" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rop-5J-Rfx" userLabel="ContentLabel">
+                            <rect key="frame" x="10" y="0.0" width="319" height="101.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BTX-st-9cE" userLabel="ContentImageAreaView">
+                            <rect key="frame" x="10" y="101.5" width="319" height="87"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstItem="rop-5J-Rfx" firstAttribute="top" secondItem="QHV-Wf-hde" secondAttribute="top" id="Cvk-6K-2yH"/>
+                        <constraint firstItem="rop-5J-Rfx" firstAttribute="leading" secondItem="QHV-Wf-hde" secondAttribute="leading" constant="10" id="LYv-bA-pfR"/>
+                        <constraint firstAttribute="trailing" secondItem="BTX-st-9cE" secondAttribute="trailing" constant="10" id="MWF-km-J8V"/>
+                        <constraint firstAttribute="bottom" secondItem="BTX-st-9cE" secondAttribute="bottom" id="Q1F-h4-iym"/>
+                        <constraint firstAttribute="trailing" secondItem="rop-5J-Rfx" secondAttribute="trailing" constant="10" id="SOV-oR-VHh"/>
+                        <constraint firstItem="BTX-st-9cE" firstAttribute="top" secondItem="rop-5J-Rfx" secondAttribute="bottom" id="ViQ-u5-20O"/>
+                        <constraint firstItem="BTX-st-9cE" firstAttribute="leading" secondItem="QHV-Wf-hde" secondAttribute="leading" constant="10" id="ncr-1V-G1V"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="Ke5-eo-y6p" secondAttribute="trailing" id="0l0-kT-b0y"/>
+                <constraint firstItem="eYZ-my-eaS" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="2qa-JK-kgY"/>
+                <constraint firstItem="QHV-Wf-hde" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="5FT-eb-Ohi"/>
+                <constraint firstItem="Ke5-eo-y6p" firstAttribute="top" secondItem="cAr-hJ-nID" secondAttribute="bottom" id="8ck-l6-rah"/>
+                <constraint firstAttribute="trailing" secondItem="QHV-Wf-hde" secondAttribute="trailing" id="BAT-h3-gvq"/>
+                <constraint firstItem="QHV-Wf-hde" firstAttribute="top" secondItem="eYZ-my-eaS" secondAttribute="bottom" id="EOd-vO-Wpv"/>
+                <constraint firstItem="Ke5-eo-y6p" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="ROG-Ta-8dM"/>
+                <constraint firstItem="eYZ-my-eaS" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="SHv-MC-m1c"/>
+                <constraint firstAttribute="bottom" secondItem="Ke5-eo-y6p" secondAttribute="bottom" id="U3m-M8-8hS"/>
+                <constraint firstItem="cAr-hJ-nID" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="YnZ-S3-enS"/>
+                <constraint firstAttribute="trailing" secondItem="eYZ-my-eaS" secondAttribute="trailing" id="grk-6i-bK4"/>
+                <constraint firstItem="cAr-hJ-nID" firstAttribute="top" secondItem="QHV-Wf-hde" secondAttribute="bottom" id="tT9-va-psZ"/>
+                <constraint firstAttribute="trailing" secondItem="cAr-hJ-nID" secondAttribute="trailing" id="wW3-vd-ZpA"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="contentImageAreaView" destination="BTX-st-9cE" id="oN7-4W-iSt"/>
+                <outlet property="contentLabel" destination="rop-5J-Rfx" id="7ag-m5-Rjj"/>
+                <outlet property="dateLabel" destination="FEu-nk-6nc" id="LXN-19-3ix"/>
+                <outlet property="likeLabel" destination="CpS-ba-mZ3" id="603-Io-fFu"/>
+                <outlet property="nameLabel" destination="shY-e9-mcG" id="W0Q-Oj-h4g"/>
+                <outlet property="profileImageView" destination="y0U-fP-pEV" id="9mH-5R-sqQ"/>
+                <outlet property="retweetLabel" destination="U8b-Uo-l2s" id="9E9-Uv-7pZ"/>
+                <outlet property="screenNameLabel" destination="eLd-XX-deS" id="CHd-iY-jTc"/>
+            </connections>
+            <point key="canvasLocation" x="46.5" y="79"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="sample.jpg" width="10" height="8"/>
+    </resources>
+</document>

--- a/Tsuitta/View/Tweet/TweetDetailView.swift
+++ b/Tsuitta/View/Tweet/TweetDetailView.swift
@@ -1,6 +1,7 @@
 import UIKit
 import TwitterKit
 
+/// ツイート詳細画面のView部分
 class TweetDetailView: UIView, UITableViewDelegate, UITableViewDataSource {
     
     private var mainTweetData: TWTRTweet?

--- a/Tsuitta/View/Tweet/TweetDetailView.swift
+++ b/Tsuitta/View/Tweet/TweetDetailView.swift
@@ -1,0 +1,49 @@
+import UIKit
+import TwitterKit
+
+class TweetDetailView: UIView, UITableViewDelegate, UITableViewDataSource {
+    
+    private var mainTweetData: TWTRTweet?
+    
+    @IBOutlet weak private var tableView: UITableView!{
+        didSet{
+            self.tableView.delegate = self
+            self.tableView.dataSource = self
+            
+            self.tableView.estimatedRowHeight = 200
+            self.tableView.rowHeight = UITableViewAutomaticDimension
+        }
+    }
+    
+    private func createMainTweetDetailTableViewCell() -> MainTweetDetailTableViewCell? {
+        guard let tweet = mainTweetData else{
+            return nil
+        }
+        
+        guard let cell = UINib(nibName: "MainTweetDetailTableViewCell", bundle: nil).instantiateWithOwner(self, options: nil).first as? MainTweetDetailTableViewCell else {
+            return nil
+        }
+        
+        cell.selectionStyle = .None
+        cell.setup(tweet)
+        
+        
+        return cell
+    }
+    
+    func reloadMainTweetData(tweetData: TWTRTweet) {
+        self.mainTweetData = tweetData
+        
+        self.tableView.reloadData()
+    }
+    
+    //MARK: TableView
+    
+    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        return createMainTweetDetailTableViewCell() ?? UITableViewCell()
+    }
+}

--- a/Tsuitta/View/Tweet/TweetDetailView.xib
+++ b/Tsuitta/View/Tweet/TweetDetailView.xib
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="TweetDetailView" customModule="Tsuitta" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="QYZ-zC-Iy5">
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                </tableView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="QYZ-zC-Iy5" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="Afn-Y1-bx7"/>
+                <constraint firstAttribute="bottom" secondItem="QYZ-zC-Iy5" secondAttribute="bottom" id="Gy2-aH-84u"/>
+                <constraint firstAttribute="trailing" secondItem="QYZ-zC-Iy5" secondAttribute="trailing" id="Kqd-77-SvB"/>
+                <constraint firstItem="QYZ-zC-Iy5" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="RBX-x3-ajY"/>
+            </constraints>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+            <connections>
+                <outlet property="tableView" destination="QYZ-zC-Iy5" id="PBN-rT-RyA"/>
+            </connections>
+        </view>
+    </objects>
+</document>


### PR DESCRIPTION
ツイート詳細画面の構成としては、メインのツイートとその下にリプが並ぶイメージだが、今回はメインのツイート部分しか作っていない。
リプの部分に関しては、タイムラインのツイートのセルができたらそれを使って実装する予定。

今回の主な実装
- ツイート詳細画面のVC作成(↓のViewを読み込んでloadViewでself.viewに追加しているだけ)
- ツイート詳細画面のViewを作成(とりあえずtableViewがあるだけ)
- ツイート詳細画面のMainのView部分を作成　下記3つの構成で作成
  - リツイートしている場合に表示される、〇〇さんがリツート部分のView
  - 具体的なTweet部分(アカウント情報も含む)のView　別のxibファイルに分けて実装している
  - アクションボタン(リプ、リツ、Like、その他)がおいてあるView　具体的な動作に関しては実装していなく、ボタンがおいてあるだけ

主に、レイアウト関連のことしかしていないので、適当にLoginViewControllerあたりに

```
    override func viewDidAppear(animated: Bool) {
        super.viewDidAppear(animated)

        navigationController?.pushViewController(TweetDetailViewController(), animated: true)
    }
```

を追加すれば見れます。
