### PR TITLE
ユーザー詳細画面のレイアウト的なや～つ

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,4 @@
 github "SwiftyJSON/SwiftyJSON"
 github "Alamofire/Alamofire" ~> 3.0
 github "kitasuke/PagingMenuController"
+github "rs/SDWebImage"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,4 @@
-github "Alamofire/Alamofire" "3.1.4"
-github "kitasuke/PagingMenuController" "0.7.7"
+github "Alamofire/Alamofire" "3.2.0"
+github "kitasuke/PagingMenuController" "0.7.9"
+github "rs/SDWebImage" "3.7.5"
 github "SwiftyJSON/SwiftyJSON" "2.3.3"

--- a/Tsuitta.xcodeproj/project.pbxproj
+++ b/Tsuitta.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		259DD39D1C00611A00C9B7CE /* SwiftyJSON.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 259DD3951C005D1A00C9B7CE /* SwiftyJSON.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		259DD39E1C00611A00C9B7CE /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 259DD3931C005D0E00C9B7CE /* Alamofire.framework */; };
 		259DD39F1C00611A00C9B7CE /* Alamofire.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 259DD3931C005D0E00C9B7CE /* Alamofire.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		259EB8311C674296002A3ED9 /* UserDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259EB8301C674296002A3ED9 /* UserDetailViewController.swift */; };
 		25D441DD1C2527F600C84D58 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D441DC1C2527F600C84D58 /* APIClient.swift */; };
 		25D441DF1C26AFA400C84D58 /* debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D441DE1C26AFA400C84D58 /* debug.swift */; };
 /* End PBXBuildFile section */
@@ -144,6 +145,7 @@
 		259DD3901C004E1100C9B7CE /* LoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		259DD3931C005D0E00C9B7CE /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
 		259DD3951C005D1A00C9B7CE /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyJSON.framework; path = Carthage/Build/iOS/SwiftyJSON.framework; sourceTree = "<group>"; };
+		259EB8301C674296002A3ED9 /* UserDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDetailViewController.swift; sourceTree = "<group>"; };
 		25D441DC1C2527F600C84D58 /* APIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		25D441DE1C26AFA400C84D58 /* debug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = debug.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -293,6 +295,7 @@
 				0652FC6C1C1D5692005006D3 /* HomeViewController.swift */,
 				2524D5851C54D2E600703B27 /* TweetDetailViewController.swift */,
 				2524D5951C5DD3E500703B27 /* TweetComposeViewController.swift */,
+				259EB8301C674296002A3ED9 /* UserDetailViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -708,6 +711,7 @@
 				0652FC6D1C1D5692005006D3 /* HomeViewController.swift in Sources */,
 				0652FC7A1C1D7C65005006D3 /* UIColor+hex.swift in Sources */,
 				2524D5961C5DD3E500703B27 /* TweetComposeViewController.swift in Sources */,
+				259EB8311C674296002A3ED9 /* UserDetailViewController.swift in Sources */,
 				25590FA31C4103D10024CEC3 /* SearchAPIManager.swift in Sources */,
 				259DD3911C004E1100C9B7CE /* LoginViewController.swift in Sources */,
 				25D441DF1C26AFA400C84D58 /* debug.swift in Sources */,

--- a/Tsuitta.xcodeproj/project.pbxproj
+++ b/Tsuitta.xcodeproj/project.pbxproj
@@ -56,8 +56,15 @@
 		259DD39E1C00611A00C9B7CE /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 259DD3931C005D0E00C9B7CE /* Alamofire.framework */; };
 		259DD39F1C00611A00C9B7CE /* Alamofire.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 259DD3931C005D0E00C9B7CE /* Alamofire.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		259EB8311C674296002A3ED9 /* UserDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259EB8301C674296002A3ED9 /* UserDetailViewController.swift */; };
+		259EB8351C6EF189002A3ED9 /* UserDetailView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 259EB8341C6EF189002A3ED9 /* UserDetailView.xib */; };
+		259EB8371C6EF195002A3ED9 /* UserDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259EB8361C6EF195002A3ED9 /* UserDetailView.swift */; };
+		259EB8391C6EF3CF002A3ED9 /* UserDetailInfoViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259EB8381C6EF3CF002A3ED9 /* UserDetailInfoViewCell.swift */; };
+		259EB83B1C6EF3D7002A3ED9 /* UserDetailActionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259EB83A1C6EF3D7002A3ED9 /* UserDetailActionViewCell.swift */; };
+		259EB83D1C6EF3F5002A3ED9 /* UserDetailInfoViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 259EB83C1C6EF3F5002A3ED9 /* UserDetailInfoViewCell.xib */; };
+		259EB83F1C6EF408002A3ED9 /* UserDetailActionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 259EB83E1C6EF408002A3ED9 /* UserDetailActionViewCell.xib */; };
 		259EB8411C6F05C0002A3ED9 /* WebImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 259EB8401C6F05C0002A3ED9 /* WebImage.framework */; };
 		259EB8421C6F05C0002A3ED9 /* WebImage.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 259EB8401C6F05C0002A3ED9 /* WebImage.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		259EB8441C6F08DF002A3ED9 /* ProfileDetailData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259EB8431C6F08DF002A3ED9 /* ProfileDetailData.swift */; };
 		25D441DD1C2527F600C84D58 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D441DC1C2527F600C84D58 /* APIClient.swift */; };
 		25D441DF1C26AFA400C84D58 /* debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D441DE1C26AFA400C84D58 /* debug.swift */; };
 /* End PBXBuildFile section */
@@ -149,7 +156,14 @@
 		259DD3931C005D0E00C9B7CE /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
 		259DD3951C005D1A00C9B7CE /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyJSON.framework; path = Carthage/Build/iOS/SwiftyJSON.framework; sourceTree = "<group>"; };
 		259EB8301C674296002A3ED9 /* UserDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDetailViewController.swift; sourceTree = "<group>"; };
+		259EB8341C6EF189002A3ED9 /* UserDetailView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = UserDetailView.xib; sourceTree = "<group>"; };
+		259EB8361C6EF195002A3ED9 /* UserDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDetailView.swift; sourceTree = "<group>"; };
+		259EB8381C6EF3CF002A3ED9 /* UserDetailInfoViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDetailInfoViewCell.swift; sourceTree = "<group>"; };
+		259EB83A1C6EF3D7002A3ED9 /* UserDetailActionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDetailActionViewCell.swift; sourceTree = "<group>"; };
+		259EB83C1C6EF3F5002A3ED9 /* UserDetailInfoViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = UserDetailInfoViewCell.xib; sourceTree = "<group>"; };
+		259EB83E1C6EF408002A3ED9 /* UserDetailActionViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = UserDetailActionViewCell.xib; sourceTree = "<group>"; };
 		259EB8401C6F05C0002A3ED9 /* WebImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebImage.framework; path = Carthage/Build/iOS/WebImage.framework; sourceTree = "<group>"; };
+		259EB8431C6F08DF002A3ED9 /* ProfileDetailData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileDetailData.swift; sourceTree = "<group>"; };
 		25D441DC1C2527F600C84D58 /* APIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		25D441DE1C26AFA400C84D58 /* debug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = debug.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -429,6 +443,7 @@
 		259DD37F1C004D4300C9B7CE /* DataBase */ = {
 			isa = PBXGroup;
 			children = (
+				259EB8431C6F08DF002A3ED9 /* ProfileDetailData.swift */,
 			);
 			name = DataBase;
 			path = UserData;
@@ -536,6 +551,12 @@
 		259DD38B1C004D4300C9B7CE /* User */ = {
 			isa = PBXGroup;
 			children = (
+				259EB8341C6EF189002A3ED9 /* UserDetailView.xib */,
+				259EB8361C6EF195002A3ED9 /* UserDetailView.swift */,
+				259EB83C1C6EF3F5002A3ED9 /* UserDetailInfoViewCell.xib */,
+				259EB8381C6EF3CF002A3ED9 /* UserDetailInfoViewCell.swift */,
+				259EB83E1C6EF408002A3ED9 /* UserDetailActionViewCell.xib */,
+				259EB83A1C6EF3D7002A3ED9 /* UserDetailActionViewCell.swift */,
 			);
 			path = User;
 			sourceTree = "<group>";
@@ -663,6 +684,8 @@
 				2575594E1C12C2D30031B6CF /* TwitterKitResources.bundle in Resources */,
 				2524D59B1C5DD4B500703B27 /* TweetComposeView.xib in Resources */,
 				0652FC711C1D5856005006D3 /* HomeView.xib in Resources */,
+				259EB83D1C6EF3F5002A3ED9 /* UserDetailInfoViewCell.xib in Resources */,
+				259EB83F1C6EF408002A3ED9 /* UserDetailActionViewCell.xib in Resources */,
 				0652FC661C1D4F69005006D3 /* TabBar.storyboard in Resources */,
 				259DD3411C00429B00C9B7CE /* LaunchScreen.storyboard in Resources */,
 				25590FCF1C4258FC0024CEC3 /* sample.jpg in Resources */,
@@ -670,6 +693,7 @@
 				259DD33C1C00429B00C9B7CE /* Main.storyboard in Resources */,
 				253D5E871C148E6600D59DC0 /* icon.jpg in Resources */,
 				257559561C12E3250031B6CF /* LoginView.xib in Resources */,
+				259EB8351C6EF189002A3ED9 /* UserDetailView.xib in Resources */,
 				2524D58A1C54D36D00703B27 /* TweetDetailView.xib in Resources */,
 				2524D58C1C54D65600703B27 /* MainTweetDetailTableViewCell.xib in Resources */,
 				2524D5921C55029100703B27 /* MainTweetView.xib in Resources */,
@@ -721,11 +745,14 @@
 				25590FA31C4103D10024CEC3 /* SearchAPIManager.swift in Sources */,
 				259DD3911C004E1100C9B7CE /* LoginViewController.swift in Sources */,
 				25D441DF1C26AFA400C84D58 /* debug.swift in Sources */,
+				259EB8441C6F08DF002A3ED9 /* ProfileDetailData.swift in Sources */,
 				259DD3371C00429B00C9B7CE /* AppDelegate.swift in Sources */,
 				25590F991C391D660024CEC3 /* TimeLineViewController.swift in Sources */,
 				25590F9D1C40F07B0024CEC3 /* APILocator.swift in Sources */,
 				257559541C12E3160031B6CF /* LoginView.swift in Sources */,
+				259EB8391C6EF3CF002A3ED9 /* UserDetailInfoViewCell.swift in Sources */,
 				2524D59D1C5DDCE700703B27 /* UIView+BorderForIB.swift in Sources */,
+				259EB8371C6EF195002A3ED9 /* UserDetailView.swift in Sources */,
 				25D441DD1C2527F600C84D58 /* APIClient.swift in Sources */,
 				0652FC781C1D77F2005006D3 /* ConstantColor.swift in Sources */,
 				2524D5861C54D2E600703B27 /* TweetDetailViewController.swift in Sources */,
@@ -737,6 +764,7 @@
 				25590FA11C4103930024CEC3 /* TweetAPIManager.swift in Sources */,
 				25590FCD1C424D7F0024CEC3 /* SettingAPIManager.swift in Sources */,
 				2524D5881C54D36200703B27 /* TweetDetailView.swift in Sources */,
+				259EB83B1C6EF3D7002A3ED9 /* UserDetailActionViewCell.swift in Sources */,
 				257559511C12C39D0031B6CF /* PagingController.swift in Sources */,
 				2524D5941C550D0700703B27 /* UIView+Constraint.swift in Sources */,
 			);

--- a/Tsuitta.xcodeproj/project.pbxproj
+++ b/Tsuitta.xcodeproj/project.pbxproj
@@ -56,6 +56,8 @@
 		259DD39E1C00611A00C9B7CE /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 259DD3931C005D0E00C9B7CE /* Alamofire.framework */; };
 		259DD39F1C00611A00C9B7CE /* Alamofire.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 259DD3931C005D0E00C9B7CE /* Alamofire.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		259EB8311C674296002A3ED9 /* UserDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259EB8301C674296002A3ED9 /* UserDetailViewController.swift */; };
+		259EB8411C6F05C0002A3ED9 /* WebImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 259EB8401C6F05C0002A3ED9 /* WebImage.framework */; };
+		259EB8421C6F05C0002A3ED9 /* WebImage.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 259EB8401C6F05C0002A3ED9 /* WebImage.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		25D441DD1C2527F600C84D58 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D441DC1C2527F600C84D58 /* APIClient.swift */; };
 		25D441DF1C26AFA400C84D58 /* debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D441DE1C26AFA400C84D58 /* debug.swift */; };
 /* End PBXBuildFile section */
@@ -87,6 +89,7 @@
 				259DD39D1C00611A00C9B7CE /* SwiftyJSON.framework in Embed Frameworks */,
 				0652FC691C1D5133005006D3 /* PagingMenuController.framework in Embed Frameworks */,
 				259DD39F1C00611A00C9B7CE /* Alamofire.framework in Embed Frameworks */,
+				259EB8421C6F05C0002A3ED9 /* WebImage.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -146,6 +149,7 @@
 		259DD3931C005D0E00C9B7CE /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
 		259DD3951C005D1A00C9B7CE /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyJSON.framework; path = Carthage/Build/iOS/SwiftyJSON.framework; sourceTree = "<group>"; };
 		259EB8301C674296002A3ED9 /* UserDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDetailViewController.swift; sourceTree = "<group>"; };
+		259EB8401C6F05C0002A3ED9 /* WebImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebImage.framework; path = Carthage/Build/iOS/WebImage.framework; sourceTree = "<group>"; };
 		25D441DC1C2527F600C84D58 /* APIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		25D441DE1C26AFA400C84D58 /* debug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = debug.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -159,6 +163,7 @@
 				0652FC681C1D5133005006D3 /* PagingMenuController.framework in Frameworks */,
 				259DD39C1C00611A00C9B7CE /* SwiftyJSON.framework in Frameworks */,
 				259DD39E1C00611A00C9B7CE /* Alamofire.framework in Frameworks */,
+				259EB8411C6F05C0002A3ED9 /* WebImage.framework in Frameworks */,
 				2575594C1C12C2D30031B6CF /* Fabric.framework in Frameworks */,
 				2575594D1C12C2D30031B6CF /* TwitterKit.framework in Frameworks */,
 			);
@@ -220,6 +225,7 @@
 		259DD32A1C00429A00C9B7CE = {
 			isa = PBXGroup;
 			children = (
+				259EB8401C6F05C0002A3ED9 /* WebImage.framework */,
 				0652FC671C1D5133005006D3 /* PagingMenuController.framework */,
 				259DD3921C00530C00C9B7CE /* Framework */,
 				259DD3351C00429A00C9B7CE /* Tsuitta */,

--- a/Tsuitta/Controller/UserDetailViewController.swift
+++ b/Tsuitta/Controller/UserDetailViewController.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+class UserDetailViewController: UIViewController {
+    
+}

--- a/Tsuitta/Controller/UserDetailViewController.swift
+++ b/Tsuitta/Controller/UserDetailViewController.swift
@@ -2,4 +2,23 @@ import UIKit
 
 class UserDetailViewController: UIViewController {
     
+    
+    override func loadView() {
+        super.loadView()
+        
+        if let view = UINib(nibName: "UserDetailView", bundle: nil).instantiateWithOwner(self, options: nil).first as? UserDetailView {
+            self.view = view
+        }
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        APILocator.sharedInstance.user.profileDetailData(Int(APILocator.sharedInstance.user.id()!)!) { (profileDetailData) -> Void in
+            guard let v = self.view as? UserDetailView else {
+                return
+            }
+            v.reloadProfileData(profileDetailData)
+        }
+    }
 }

--- a/Tsuitta/Model/API/UserAPIManager.swift
+++ b/Tsuitta/Model/API/UserAPIManager.swift
@@ -61,6 +61,19 @@ class UserAPIManager {
         }
     }
     
+    //TODO:とりあえず適当に作ります。あとで修正してね！
+    func profileDetailData(userId: Int, callback: ProfileDetailData -> Void) {
+        let id = String(userId)
+        APIClient.get("/users/show.json", parameter: ["user_id": id]) { (response, data, error) -> Void in
+            if let err = error {
+                debug("エラーだよ：\(err.description)")
+                return
+            }
+            let profile = ProfileDetailData(json: JSON(data: data!))
+            callback(profile)
+        }
+    }
+    
     //MARK: Follow
     
     func follow(userId: Int){

--- a/Tsuitta/Model/UserData/ProfileDetailData.swift
+++ b/Tsuitta/Model/UserData/ProfileDetailData.swift
@@ -1,0 +1,47 @@
+import SwiftyJSON
+
+struct ProfileDetailData {
+    
+    private(set) var userID = 0
+    
+    private(set) var name = ""
+    
+    private(set) var screenName = ""
+    
+    private(set) var description = ""
+    
+    private(set) var location = ""
+    
+    private(set) var url = ""
+    
+    private(set) var followersCount = 0
+    
+    private(set) var friendsCount = 0
+    
+    private(set) var favouritesCount = 0
+    
+    //Tweet数？
+    private(set) var statusesCount = 0
+    
+    private(set) var profileBannerURL = ""
+    
+    private(set) var profileImageURL = ""
+    
+    private(set) var following:Bool
+    
+    init(json: JSON) {
+        self.userID = json["id"].intValue
+        self.name = json["name"].stringValue
+        self.screenName = json["screen_name"].stringValue
+        self.description = json["description"].stringValue
+        self.location = json["location"].stringValue
+        self.url = json["url"].stringValue
+        self.followersCount = json["followers_count"].intValue
+        self.friendsCount = json["friends_count"].intValue
+        self.favouritesCount = json["favourites_count"].intValue
+        self.statusesCount = json["statuses_count"].intValue
+        self.profileBannerURL = json["profile_banner_url"].stringValue
+        self.profileImageURL = json["profile_image_url"].stringValue
+        self.following = json["following"].boolValue
+    }
+}

--- a/Tsuitta/View/User/UserDetailActionViewCell.swift
+++ b/Tsuitta/View/User/UserDetailActionViewCell.swift
@@ -1,0 +1,29 @@
+import UIKit
+
+class UserDetailActionViewCell: UITableViewCell {
+
+    @IBOutlet weak var followCountLabel: UILabel!
+    
+    @IBOutlet weak var followerCountLabel: UILabel!
+    
+    @IBOutlet weak var tweetCountLabel: UILabel!
+    
+    
+    @IBOutlet weak var likeCountLabel: UILabel!
+    
+    @IBAction func didTapActionButton(sender: UIButton) {
+        //TODO: 実装してね！
+    }
+    
+    
+    @IBAction func didTapFollowButton(sender: UIButton) {
+        //TODO: 実装してね！
+    }
+    
+    func setup(profileData: ProfileDetailData) {
+        self.followCountLabel.text = String(profileData.friendsCount)
+        self.followerCountLabel.text = String(profileData.followersCount)
+        self.tweetCountLabel.text = String(profileData.statusesCount)
+        self.likeCountLabel.text = String(profileData.favouritesCount)
+    }
+}

--- a/Tsuitta/View/User/UserDetailActionViewCell.xib
+++ b/Tsuitta/View/User/UserDetailActionViewCell.xib
@@ -1,0 +1,429 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="infinite" id="iN0-l3-epB" customClass="UserDetailActionViewCell" customModule="Tsuitta" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="infinite" axis="vertical" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0pm-Fs-eWU">
+                    <rect key="frame" x="20" y="20" width="280" height="152"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U6H-ay-Sxi">
+                            <rect key="frame" x="0.0" y="0.0" width="280" height="40"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="7Fc-dz-UKT">
+                                    <rect key="frame" x="0.0" y="0.0" width="280" height="40"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cDs-mT-YgM">
+                                            <rect key="frame" x="0.0" y="0.0" width="130" height="40"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Oaa-ji-MUW">
+                                                    <rect key="frame" x="0.0" y="0.0" width="130" height="40"/>
+                                                    <subviews>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8la-fC-bmc">
+                                                            <rect key="frame" x="0.0" y="0.0" width="130" height="20"/>
+                                                            <subviews>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="100" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="5sS-e7-p5F">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="130" height="19.5"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                            <constraints>
+                                                                <constraint firstItem="5sS-e7-p5F" firstAttribute="leading" secondItem="8la-fC-bmc" secondAttribute="leading" id="07g-fY-R2M"/>
+                                                                <constraint firstAttribute="bottom" secondItem="5sS-e7-p5F" secondAttribute="bottom" id="aNr-EG-S62"/>
+                                                                <constraint firstAttribute="trailing" secondItem="5sS-e7-p5F" secondAttribute="trailing" id="e5K-dV-y6S"/>
+                                                                <constraint firstItem="5sS-e7-p5F" firstAttribute="top" secondItem="8la-fC-bmc" secondAttribute="top" id="h3S-W4-vQ6"/>
+                                                            </constraints>
+                                                        </view>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NWg-Kt-m0Q">
+                                                            <rect key="frame" x="0.0" y="20" width="130" height="20"/>
+                                                            <subviews>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="フォロー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Uj7-S4-VNf">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="130" height="20"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                            <constraints>
+                                                                <constraint firstItem="Uj7-S4-VNf" firstAttribute="top" secondItem="NWg-Kt-m0Q" secondAttribute="top" id="5fH-WK-hwl"/>
+                                                                <constraint firstAttribute="bottom" secondItem="Uj7-S4-VNf" secondAttribute="bottom" id="FpS-cj-tL2"/>
+                                                                <constraint firstItem="Uj7-S4-VNf" firstAttribute="leading" secondItem="NWg-Kt-m0Q" secondAttribute="leading" id="TEx-XG-TYl"/>
+                                                                <constraint firstAttribute="trailing" secondItem="Uj7-S4-VNf" secondAttribute="trailing" id="xs1-lQ-Rdi"/>
+                                                            </constraints>
+                                                        </view>
+                                                    </subviews>
+                                                </stackView>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstItem="Oaa-ji-MUW" firstAttribute="top" secondItem="cDs-mT-YgM" secondAttribute="top" id="2a6-vR-hQo"/>
+                                                <constraint firstItem="Oaa-ji-MUW" firstAttribute="leading" secondItem="cDs-mT-YgM" secondAttribute="leading" id="8qw-bq-aPX"/>
+                                                <constraint firstAttribute="trailing" secondItem="Oaa-ji-MUW" secondAttribute="trailing" id="Jal-sV-K1c"/>
+                                                <constraint firstAttribute="bottom" secondItem="Oaa-ji-MUW" secondAttribute="bottom" id="Wep-ou-GbQ"/>
+                                            </constraints>
+                                            <userDefinedRuntimeAttributes>
+                                                <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                    <real key="value" value="1"/>
+                                                </userDefinedRuntimeAttribute>
+                                                <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                    <color key="value" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                </userDefinedRuntimeAttribute>
+                                            </userDefinedRuntimeAttributes>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vqd-jP-WQQ">
+                                            <rect key="frame" x="150" y="0.0" width="130" height="40"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="NoR-2q-jMQ">
+                                                    <rect key="frame" x="0.0" y="0.0" width="130" height="40"/>
+                                                    <subviews>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cDe-pA-iIO">
+                                                            <rect key="frame" x="0.0" y="0.0" width="130" height="20"/>
+                                                            <subviews>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="100" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="jo5-hx-mbV">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="130" height="19.5"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="trailing" secondItem="jo5-hx-mbV" secondAttribute="trailing" id="KdX-9P-VwR"/>
+                                                                <constraint firstItem="jo5-hx-mbV" firstAttribute="top" secondItem="cDe-pA-iIO" secondAttribute="top" id="MNA-RR-xYQ"/>
+                                                                <constraint firstItem="jo5-hx-mbV" firstAttribute="leading" secondItem="cDe-pA-iIO" secondAttribute="leading" id="WI9-M9-8L5"/>
+                                                                <constraint firstAttribute="bottom" secondItem="jo5-hx-mbV" secondAttribute="bottom" id="zbx-pM-1vb"/>
+                                                            </constraints>
+                                                        </view>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AAC-ll-6bu">
+                                                            <rect key="frame" x="0.0" y="20" width="130" height="20"/>
+                                                            <subviews>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="フォロワー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHK-ec-geF">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="130" height="20"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                            <constraints>
+                                                                <constraint firstItem="EHK-ec-geF" firstAttribute="leading" secondItem="AAC-ll-6bu" secondAttribute="leading" id="VgP-8U-tZZ"/>
+                                                                <constraint firstAttribute="trailing" secondItem="EHK-ec-geF" secondAttribute="trailing" id="Wzf-na-jzs"/>
+                                                                <constraint firstAttribute="bottom" secondItem="EHK-ec-geF" secondAttribute="bottom" id="gLE-wa-VKr"/>
+                                                                <constraint firstItem="EHK-ec-geF" firstAttribute="top" secondItem="AAC-ll-6bu" secondAttribute="top" id="nEs-5T-ckn"/>
+                                                            </constraints>
+                                                        </view>
+                                                    </subviews>
+                                                </stackView>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstItem="NoR-2q-jMQ" firstAttribute="leading" secondItem="Vqd-jP-WQQ" secondAttribute="leading" id="1am-FF-Voz"/>
+                                                <constraint firstItem="NoR-2q-jMQ" firstAttribute="top" secondItem="Vqd-jP-WQQ" secondAttribute="top" id="2O1-UW-Vjd"/>
+                                                <constraint firstAttribute="bottom" secondItem="NoR-2q-jMQ" secondAttribute="bottom" id="IG5-zj-jCL"/>
+                                                <constraint firstAttribute="trailing" secondItem="NoR-2q-jMQ" secondAttribute="trailing" id="ZgJ-Vs-eXp"/>
+                                            </constraints>
+                                            <userDefinedRuntimeAttributes>
+                                                <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                    <real key="value" value="1"/>
+                                                </userDefinedRuntimeAttribute>
+                                                <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                    <color key="value" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                                </userDefinedRuntimeAttribute>
+                                            </userDefinedRuntimeAttributes>
+                                        </view>
+                                    </subviews>
+                                </stackView>
+                            </subviews>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <constraints>
+                                <constraint firstAttribute="trailing" secondItem="7Fc-dz-UKT" secondAttribute="trailing" id="18K-pZ-8TQ"/>
+                                <constraint firstItem="7Fc-dz-UKT" firstAttribute="top" secondItem="U6H-ay-Sxi" secondAttribute="top" id="3Pd-jq-O9n"/>
+                                <constraint firstAttribute="bottom" secondItem="7Fc-dz-UKT" secondAttribute="bottom" id="NSe-m6-gmX"/>
+                                <constraint firstAttribute="height" constant="40" id="j4F-F3-7HO"/>
+                                <constraint firstItem="7Fc-dz-UKT" firstAttribute="leading" secondItem="U6H-ay-Sxi" secondAttribute="leading" id="tE3-ZQ-BnZ"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Vc-M7-fuK">
+                            <rect key="frame" x="0.0" y="56" width="280" height="40"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="76t-Ph-wa0">
+                                    <rect key="frame" x="0.0" y="0.0" width="280" height="40"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lHq-3A-JCA">
+                                            <rect key="frame" x="0.0" y="0.0" width="130" height="40"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="zHA-Uc-qC1">
+                                                    <rect key="frame" x="5" y="5" width="120" height="30"/>
+                                                    <subviews>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VE4-s2-0CA">
+                                                            <rect key="frame" x="0.0" y="0.0" width="120" height="15"/>
+                                                            <subviews>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="100" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="eEJ-sq-u9O">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="120" height="14.5"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                            <constraints>
+                                                                <constraint firstItem="eEJ-sq-u9O" firstAttribute="leading" secondItem="VE4-s2-0CA" secondAttribute="leading" id="FZJ-cl-s2y"/>
+                                                                <constraint firstAttribute="trailing" secondItem="eEJ-sq-u9O" secondAttribute="trailing" id="GyX-gD-2NU"/>
+                                                                <constraint firstAttribute="bottom" secondItem="eEJ-sq-u9O" secondAttribute="bottom" id="Taz-2k-JsC"/>
+                                                                <constraint firstItem="eEJ-sq-u9O" firstAttribute="top" secondItem="VE4-s2-0CA" secondAttribute="top" id="cRg-FM-BbG"/>
+                                                            </constraints>
+                                                        </view>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e1I-rN-vfF">
+                                                            <rect key="frame" x="0.0" y="15" width="120" height="15"/>
+                                                            <subviews>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ツイート" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="p9f-IC-2oY">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="120" height="14.5"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="bottom" secondItem="p9f-IC-2oY" secondAttribute="bottom" id="0za-NU-Xtx"/>
+                                                                <constraint firstAttribute="trailing" secondItem="p9f-IC-2oY" secondAttribute="trailing" id="Tvv-43-5jp"/>
+                                                                <constraint firstItem="p9f-IC-2oY" firstAttribute="leading" secondItem="e1I-rN-vfF" secondAttribute="leading" id="Z0f-bw-ljf"/>
+                                                                <constraint firstItem="p9f-IC-2oY" firstAttribute="top" secondItem="e1I-rN-vfF" secondAttribute="top" id="fMy-cL-6pb"/>
+                                                            </constraints>
+                                                        </view>
+                                                    </subviews>
+                                                </stackView>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstItem="zHA-Uc-qC1" firstAttribute="leading" secondItem="lHq-3A-JCA" secondAttribute="leading" constant="5" id="1bW-9U-etd"/>
+                                                <constraint firstItem="zHA-Uc-qC1" firstAttribute="top" secondItem="lHq-3A-JCA" secondAttribute="top" constant="5" id="NPj-9M-pxl"/>
+                                                <constraint firstAttribute="trailing" secondItem="zHA-Uc-qC1" secondAttribute="trailing" constant="5" id="S0Y-Rb-fbc"/>
+                                                <constraint firstAttribute="bottom" secondItem="zHA-Uc-qC1" secondAttribute="bottom" constant="5" id="gob-MU-WZd"/>
+                                            </constraints>
+                                            <userDefinedRuntimeAttributes>
+                                                <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                    <real key="value" value="1"/>
+                                                </userDefinedRuntimeAttribute>
+                                                <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                    <color key="value" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                                </userDefinedRuntimeAttribute>
+                                            </userDefinedRuntimeAttributes>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Oga-R6-tEX">
+                                            <rect key="frame" x="150" y="0.0" width="130" height="40"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="F2d-Cc-R3W">
+                                                    <rect key="frame" x="5" y="5" width="120" height="30"/>
+                                                    <subviews>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6tm-N0-9Jc">
+                                                            <rect key="frame" x="0.0" y="0.0" width="120" height="15"/>
+                                                            <subviews>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="100" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Lxc-H6-Qg4">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="120" height="14.5"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="bottom" secondItem="Lxc-H6-Qg4" secondAttribute="bottom" id="7w5-k6-dJO"/>
+                                                                <constraint firstItem="Lxc-H6-Qg4" firstAttribute="leading" secondItem="6tm-N0-9Jc" secondAttribute="leading" id="Bfg-07-Yz3"/>
+                                                                <constraint firstItem="Lxc-H6-Qg4" firstAttribute="top" secondItem="6tm-N0-9Jc" secondAttribute="top" id="hmT-EE-eWZ"/>
+                                                                <constraint firstAttribute="trailing" secondItem="Lxc-H6-Qg4" secondAttribute="trailing" id="yHq-93-TMx"/>
+                                                            </constraints>
+                                                        </view>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Xt-dw-Jjo">
+                                                            <rect key="frame" x="0.0" y="15" width="120" height="15"/>
+                                                            <subviews>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="いいね" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="8CJ-Ma-x27">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="120" height="14.5"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="trailing" secondItem="8CJ-Ma-x27" secondAttribute="trailing" id="Fvu-Iw-lfo"/>
+                                                                <constraint firstAttribute="bottom" secondItem="8CJ-Ma-x27" secondAttribute="bottom" id="dHS-UU-7UZ"/>
+                                                                <constraint firstItem="8CJ-Ma-x27" firstAttribute="top" secondItem="5Xt-dw-Jjo" secondAttribute="top" id="jIS-Hk-kmR"/>
+                                                                <constraint firstItem="8CJ-Ma-x27" firstAttribute="leading" secondItem="5Xt-dw-Jjo" secondAttribute="leading" id="xOr-5U-eeE"/>
+                                                            </constraints>
+                                                        </view>
+                                                    </subviews>
+                                                </stackView>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstItem="F2d-Cc-R3W" firstAttribute="leading" secondItem="Oga-R6-tEX" secondAttribute="leading" constant="5" id="8Jv-zC-hgW"/>
+                                                <constraint firstAttribute="trailing" secondItem="F2d-Cc-R3W" secondAttribute="trailing" constant="5" id="Q9e-aS-wOz"/>
+                                                <constraint firstItem="F2d-Cc-R3W" firstAttribute="top" secondItem="Oga-R6-tEX" secondAttribute="top" constant="5" id="oQh-i5-084"/>
+                                                <constraint firstAttribute="bottom" secondItem="F2d-Cc-R3W" secondAttribute="bottom" constant="5" id="rBa-K4-34u"/>
+                                            </constraints>
+                                            <userDefinedRuntimeAttributes>
+                                                <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                    <color key="value" name="controlDarkShadowColor" catalog="System" colorSpace="catalog"/>
+                                                </userDefinedRuntimeAttribute>
+                                                <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                    <real key="value" value="1"/>
+                                                </userDefinedRuntimeAttribute>
+                                            </userDefinedRuntimeAttributes>
+                                        </view>
+                                    </subviews>
+                                </stackView>
+                            </subviews>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <constraints>
+                                <constraint firstAttribute="trailing" secondItem="76t-Ph-wa0" secondAttribute="trailing" id="4S3-Ma-L6k"/>
+                                <constraint firstAttribute="height" constant="40" id="53c-lM-0D0"/>
+                                <constraint firstAttribute="height" constant="80" id="HKh-1g-IZC"/>
+                                <constraint firstItem="76t-Ph-wa0" firstAttribute="top" secondItem="8Vc-M7-fuK" secondAttribute="top" id="MjN-Ag-g67"/>
+                                <constraint firstAttribute="bottom" secondItem="76t-Ph-wa0" secondAttribute="bottom" id="UwR-KL-HQH"/>
+                                <constraint firstItem="76t-Ph-wa0" firstAttribute="leading" secondItem="8Vc-M7-fuK" secondAttribute="leading" id="lc0-zv-Y6N"/>
+                            </constraints>
+                            <variation key="default">
+                                <mask key="constraints">
+                                    <exclude reference="HKh-1g-IZC"/>
+                                </mask>
+                            </variation>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LVQ-di-660">
+                            <rect key="frame" x="0.0" y="112" width="280" height="40"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="0ee-nt-Cob">
+                                    <rect key="frame" x="0.0" y="0.0" width="280" height="40"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kRU-wd-ay9">
+                                            <rect key="frame" x="0.0" y="0.0" width="280" height="40"/>
+                                            <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yu1-5F-XOf">
+                                                    <rect key="frame" x="0.0" y="0.0" width="50" height="39.5"/>
+                                                    <subviews>
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zAr-0L-uLv">
+                                                            <rect key="frame" x="0.0" y="0.0" width="50" height="39.5"/>
+                                                            <state key="normal" image="icon.jpg"/>
+                                                            <connections>
+                                                                <action selector="didTapActionButton:" destination="iN0-l3-epB" eventType="touchUpInside" id="5rL-ro-Fzx"/>
+                                                            </connections>
+                                                        </button>
+                                                    </subviews>
+                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="bottom" secondItem="zAr-0L-uLv" secondAttribute="bottom" id="1IL-Nk-I6Y"/>
+                                                        <constraint firstAttribute="trailing" secondItem="zAr-0L-uLv" secondAttribute="trailing" id="ESM-N6-uAb"/>
+                                                        <constraint firstItem="zAr-0L-uLv" firstAttribute="leading" secondItem="Yu1-5F-XOf" secondAttribute="leading" id="LTs-YX-Pmn"/>
+                                                        <constraint firstAttribute="width" constant="50" id="f7u-WO-xSg"/>
+                                                        <constraint firstItem="zAr-0L-uLv" firstAttribute="top" secondItem="Yu1-5F-XOf" secondAttribute="top" id="sEv-MC-pjd"/>
+                                                    </constraints>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                            <real key="value" value="1"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                            <color key="value" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </view>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vEp-t7-Fg7">
+                                                    <rect key="frame" x="70" y="0.0" width="150" height="39.5"/>
+                                                    <subviews>
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbY-gf-IZ5">
+                                                            <rect key="frame" x="0.0" y="0.0" width="150" height="39.5"/>
+                                                            <state key="normal" title="フォローする"/>
+                                                            <connections>
+                                                                <action selector="didTapFollowButton:" destination="iN0-l3-epB" eventType="touchUpInside" id="itB-gz-ykA"/>
+                                                            </connections>
+                                                        </button>
+                                                    </subviews>
+                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <constraints>
+                                                        <constraint firstItem="sbY-gf-IZ5" firstAttribute="leading" secondItem="vEp-t7-Fg7" secondAttribute="leading" id="I9L-xs-e43"/>
+                                                        <constraint firstItem="sbY-gf-IZ5" firstAttribute="top" secondItem="vEp-t7-Fg7" secondAttribute="top" id="Ukd-EX-uSc"/>
+                                                        <constraint firstAttribute="bottom" secondItem="sbY-gf-IZ5" secondAttribute="bottom" id="VkX-Bd-Xxu"/>
+                                                        <constraint firstAttribute="width" constant="150" id="sOe-Wv-I40"/>
+                                                        <constraint firstAttribute="trailing" secondItem="sbY-gf-IZ5" secondAttribute="trailing" id="sSP-Lm-IUR"/>
+                                                    </constraints>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                            <real key="value" value="1"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                            <color key="value" name="controlDarkShadowColor" catalog="System" colorSpace="catalog"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </view>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstItem="vEp-t7-Fg7" firstAttribute="leading" secondItem="Yu1-5F-XOf" secondAttribute="trailing" constant="20" id="M21-Ji-dF8"/>
+                                                <constraint firstAttribute="bottom" secondItem="Yu1-5F-XOf" secondAttribute="bottom" id="ZyN-GP-l4z"/>
+                                                <constraint firstItem="vEp-t7-Fg7" firstAttribute="top" secondItem="kRU-wd-ay9" secondAttribute="top" id="b8c-xs-uXu"/>
+                                                <constraint firstItem="Yu1-5F-XOf" firstAttribute="leading" secondItem="kRU-wd-ay9" secondAttribute="leading" id="kJX-Ib-6WD"/>
+                                                <constraint firstItem="Yu1-5F-XOf" firstAttribute="top" secondItem="kRU-wd-ay9" secondAttribute="top" id="mak-Ya-4c1"/>
+                                                <constraint firstAttribute="bottom" secondItem="vEp-t7-Fg7" secondAttribute="bottom" id="zg0-7H-994"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                </stackView>
+                            </subviews>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <constraints>
+                                <constraint firstAttribute="trailing" secondItem="0ee-nt-Cob" secondAttribute="trailing" id="4iH-vX-Fh1"/>
+                                <constraint firstItem="0ee-nt-Cob" firstAttribute="top" secondItem="LVQ-di-660" secondAttribute="top" id="Gf7-E8-nCX"/>
+                                <constraint firstItem="0ee-nt-Cob" firstAttribute="leading" secondItem="LVQ-di-660" secondAttribute="leading" id="UaB-7N-cPw"/>
+                                <constraint firstAttribute="height" constant="40" id="igm-bU-Bb0"/>
+                                <constraint firstAttribute="bottom" secondItem="0ee-nt-Cob" secondAttribute="bottom" id="vyX-Eb-dpP"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="180" id="VwD-Oh-NCy"/>
+                    </constraints>
+                    <variation key="default">
+                        <mask key="constraints">
+                            <exclude reference="VwD-Oh-NCy"/>
+                        </mask>
+                    </variation>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="0pm-Fs-eWU" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="20" id="4EB-7v-2qH"/>
+                <constraint firstAttribute="trailing" secondItem="0pm-Fs-eWU" secondAttribute="trailing" constant="20" id="BDF-7T-nrU"/>
+                <constraint firstAttribute="bottom" secondItem="0pm-Fs-eWU" secondAttribute="bottom" constant="20" id="PKx-i6-pwy"/>
+                <constraint firstItem="0pm-Fs-eWU" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="20" id="d1b-8f-k2Z"/>
+                <constraint firstItem="0pm-Fs-eWU" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" id="d3w-ii-xrU"/>
+                <constraint firstAttribute="bottom" secondItem="0pm-Fs-eWU" secondAttribute="bottom" constant="20" id="iQL-eh-CMn"/>
+            </constraints>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+            <variation key="default">
+                <mask key="constraints">
+                    <exclude reference="PKx-i6-pwy"/>
+                    <exclude reference="d1b-8f-k2Z"/>
+                </mask>
+            </variation>
+            <connections>
+                <outlet property="followCountLabel" destination="5sS-e7-p5F" id="SBu-ag-yAD"/>
+                <outlet property="followerCountLabel" destination="jo5-hx-mbV" id="gNX-JR-ViG"/>
+                <outlet property="likeCountLabel" destination="Lxc-H6-Qg4" id="LZV-pL-1sG"/>
+                <outlet property="tweetCountLabel" destination="eEJ-sq-u9O" id="Mbt-oP-beZ"/>
+            </connections>
+            <point key="canvasLocation" x="257" y="123"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="icon.jpg" width="192" height="192"/>
+    </resources>
+</document>

--- a/Tsuitta/View/User/UserDetailInfoViewCell.swift
+++ b/Tsuitta/View/User/UserDetailInfoViewCell.swift
@@ -1,0 +1,42 @@
+import UIKit
+import TwitterKit
+import WebImage
+
+class UserDetailInfoViewCell: UITableViewCell {
+    
+    @IBOutlet weak var profileBannerURL: UIImageView!
+    
+    @IBOutlet weak var profileImageView: UIImageView!
+    
+    @IBOutlet weak var nameLabel: UILabel!
+    
+    @IBOutlet weak var screenNameLabel: UILabel!
+    
+    @IBOutlet weak var descriptionLabel: UILabel!
+    
+    @IBOutlet weak var locationLabel: UILabel!
+    
+    @IBOutlet weak var urlLabel: UILabel!
+    
+    @IBOutlet weak var followerView: UIView!
+    
+    func setup(profileData: ProfileDetailData) {
+        let profileImageURL = NSURL(string: profileData.profileImageURL)
+        self.profileImageView.sd_setImageWithURL(profileImageURL)
+        
+        let profileBannerURL = NSURL(string: profileData.profileBannerURL)
+        self.profileBannerURL.sd_setImageWithURL(profileBannerURL)
+        
+        self.nameLabel.text = profileData.name
+        self.screenNameLabel.text = "@" + profileData.screenName
+        self.descriptionLabel.text = profileData.description
+        
+        self.locationLabel.text = profileData.location
+        
+        self.urlLabel.text = profileData.url
+        
+        if !profileData.following {
+            self.followerView.alpha = 0
+        }
+    }
+}

--- a/Tsuitta/View/User/UserDetailInfoViewCell.xib
+++ b/Tsuitta/View/User/UserDetailInfoViewCell.xib
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="wqb-2Z-YzF" customClass="UserDetailInfoViewCell" customModule="Tsuitta" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Ze-Ck-WDu" userLabel="BackgroundView">
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="125"/>
+                    <subviews>
+                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon.jpg" translatesAutoresizingMaskIntoConstraints="NO" id="189-Lw-sWv">
+                            <rect key="frame" x="0.0" y="0.0" width="320" height="125"/>
+                        </imageView>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstItem="189-Lw-sWv" firstAttribute="top" secondItem="8Ze-Ck-WDu" secondAttribute="top" id="Al6-Ib-6PL"/>
+                        <constraint firstAttribute="trailing" secondItem="189-Lw-sWv" secondAttribute="trailing" id="SaD-NM-2fe"/>
+                        <constraint firstAttribute="height" constant="125" id="Zdg-Id-sRX"/>
+                        <constraint firstAttribute="bottom" secondItem="189-Lw-sWv" secondAttribute="bottom" id="lke-Pt-Vfu"/>
+                        <constraint firstItem="189-Lw-sWv" firstAttribute="leading" secondItem="8Ze-Ck-WDu" secondAttribute="leading" id="vnO-JJ-xc6"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n2Z-wh-WRK" userLabel="InfoView">
+                    <rect key="frame" x="0.0" y="125" width="320" height="443"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4y1-7o-AKW">
+                            <rect key="frame" x="120" y="10" width="190" height="50"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="c0E-Fa-pKh">
+                                    <rect key="frame" x="0.0" y="0.0" width="190" height="20.5"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="F2V-m3-8j4">
+                                    <rect key="frame" x="0.0" y="20" width="190" height="29.5"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                    <color key="textColor" red="0.44850852272727271" green="0.44850852272727271" blue="0.44850852272727271" alpha="1" colorSpace="calibratedRGB"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <constraints>
+                                <constraint firstItem="c0E-Fa-pKh" firstAttribute="top" secondItem="4y1-7o-AKW" secondAttribute="top" id="2tW-y1-pXO"/>
+                                <constraint firstItem="F2V-m3-8j4" firstAttribute="top" secondItem="c0E-Fa-pKh" secondAttribute="bottom" id="3kk-dG-NsL"/>
+                                <constraint firstItem="c0E-Fa-pKh" firstAttribute="leading" secondItem="4y1-7o-AKW" secondAttribute="leading" id="Atc-Kg-I7R"/>
+                                <constraint firstAttribute="height" constant="50" id="Psf-nf-Ev2"/>
+                                <constraint firstItem="F2V-m3-8j4" firstAttribute="leading" secondItem="4y1-7o-AKW" secondAttribute="leading" id="baE-KI-LzI"/>
+                                <constraint firstAttribute="trailing" secondItem="c0E-Fa-pKh" secondAttribute="trailing" id="c3Y-Lv-QLZ"/>
+                                <constraint firstAttribute="bottom" secondItem="F2V-m3-8j4" secondAttribute="bottom" id="cl1-F4-S02"/>
+                                <constraint firstAttribute="trailing" secondItem="F2V-m3-8j4" secondAttribute="trailing" id="pXX-yg-ud8"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0ng-kQ-HSO">
+                            <rect key="frame" x="10" y="70" width="300" height="363"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="infinite" translatesAutoresizingMaskIntoConstraints="NO" id="Z4R-9z-QsZ">
+                                    <rect key="frame" x="0.0" y="0.0" width="300" height="288"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="hogheoghoehgoehgoehogheogheogheohgegheohgoehgoehogehogheoghoehgoehgoheogheogoehgo" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3fd-tv-n9a">
+                                            <rect key="frame" x="0.0" y="0.0" width="300" height="288"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <constraints>
+                                        <constraint firstItem="3fd-tv-n9a" firstAttribute="leading" secondItem="Z4R-9z-QsZ" secondAttribute="leading" id="IVJ-U3-Z3J"/>
+                                        <constraint firstAttribute="bottom" secondItem="3fd-tv-n9a" secondAttribute="bottom" id="Isj-eC-shT"/>
+                                        <constraint firstItem="3fd-tv-n9a" firstAttribute="top" secondItem="Z4R-9z-QsZ" secondAttribute="top" id="dw7-hZ-7yE"/>
+                                        <constraint firstAttribute="trailing" secondItem="3fd-tv-n9a" secondAttribute="trailing" id="wQ6-eZ-4rM"/>
+                                    </constraints>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VUJ-iU-ttU">
+                                    <rect key="frame" x="0.0" y="288" width="300" height="25"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="たるきてい" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="sRW-1R-vxz">
+                                            <rect key="frame" x="30" y="0.0" width="270" height="25"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon.jpg" translatesAutoresizingMaskIntoConstraints="NO" id="GU6-cd-3Kw">
+                                            <rect key="frame" x="0.0" y="0.0" width="30" height="25"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="30" id="qH1-ID-Z3Z"/>
+                                            </constraints>
+                                        </imageView>
+                                    </subviews>
+                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="25" id="0Vq-N1-CnU"/>
+                                        <constraint firstItem="GU6-cd-3Kw" firstAttribute="leading" secondItem="VUJ-iU-ttU" secondAttribute="leading" id="2Xu-O8-R6r"/>
+                                        <constraint firstItem="GU6-cd-3Kw" firstAttribute="top" secondItem="VUJ-iU-ttU" secondAttribute="top" id="B7e-uA-Vyx"/>
+                                        <constraint firstItem="sRW-1R-vxz" firstAttribute="leading" secondItem="GU6-cd-3Kw" secondAttribute="trailing" id="Trl-Rt-aic"/>
+                                        <constraint firstItem="sRW-1R-vxz" firstAttribute="top" secondItem="VUJ-iU-ttU" secondAttribute="top" id="c5R-bO-IXN"/>
+                                        <constraint firstAttribute="bottom" secondItem="GU6-cd-3Kw" secondAttribute="bottom" id="mCc-9k-YNd"/>
+                                        <constraint firstAttribute="trailing" secondItem="sRW-1R-vxz" secondAttribute="trailing" id="pDU-Kb-58l"/>
+                                        <constraint firstAttribute="bottom" secondItem="sRW-1R-vxz" secondAttribute="bottom" id="zqa-Gq-j5b"/>
+                                    </constraints>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qNI-FP-b4i">
+                                    <rect key="frame" x="0.0" y="313" width="300" height="25"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="http://hogehogehogheogheoghoehgoe" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Oxr-d7-hQe">
+                                            <rect key="frame" x="30" y="0.0" width="270" height="25"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon.jpg" translatesAutoresizingMaskIntoConstraints="NO" id="KHv-lB-08b">
+                                            <rect key="frame" x="0.0" y="0.0" width="30" height="25"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="30" id="Dcx-cX-vru"/>
+                                            </constraints>
+                                        </imageView>
+                                    </subviews>
+                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <constraints>
+                                        <constraint firstItem="KHv-lB-08b" firstAttribute="top" secondItem="qNI-FP-b4i" secondAttribute="top" id="0ak-ng-Ma1"/>
+                                        <constraint firstItem="KHv-lB-08b" firstAttribute="leading" secondItem="qNI-FP-b4i" secondAttribute="leading" id="2Rr-vX-K2g"/>
+                                        <constraint firstItem="Oxr-d7-hQe" firstAttribute="top" secondItem="qNI-FP-b4i" secondAttribute="top" id="EWV-Iq-uYx"/>
+                                        <constraint firstItem="Oxr-d7-hQe" firstAttribute="leading" secondItem="KHv-lB-08b" secondAttribute="trailing" id="Ve7-32-WZ2"/>
+                                        <constraint firstAttribute="bottom" secondItem="Oxr-d7-hQe" secondAttribute="bottom" id="cHM-Qj-cvN"/>
+                                        <constraint firstAttribute="trailing" secondItem="Oxr-d7-hQe" secondAttribute="trailing" id="eNT-Rb-V1e"/>
+                                        <constraint firstAttribute="bottom" secondItem="KHv-lB-08b" secondAttribute="bottom" id="kQs-Mw-s9j"/>
+                                        <constraint firstAttribute="height" constant="25" id="x6I-YM-oJg"/>
+                                    </constraints>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r0e-6S-TaN">
+                                    <rect key="frame" x="0.0" y="338" width="300" height="25"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="あなたをフォローしています" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="M9i-Od-DbS">
+                                            <rect key="frame" x="0.0" y="0.0" width="300" height="25"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" secondItem="M9i-Od-DbS" secondAttribute="bottom" id="4tM-US-xNv"/>
+                                        <constraint firstAttribute="height" constant="25" id="E5u-99-eA4"/>
+                                        <constraint firstAttribute="trailing" secondItem="M9i-Od-DbS" secondAttribute="trailing" id="NIy-VE-9xt"/>
+                                        <constraint firstItem="M9i-Od-DbS" firstAttribute="top" secondItem="r0e-6S-TaN" secondAttribute="top" id="YbO-c7-5Cn"/>
+                                        <constraint firstItem="M9i-Od-DbS" firstAttribute="leading" secondItem="r0e-6S-TaN" secondAttribute="leading" id="dH7-dL-XDA"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <constraints>
+                                <constraint firstItem="Z4R-9z-QsZ" firstAttribute="leading" secondItem="0ng-kQ-HSO" secondAttribute="leading" id="3bc-mB-aq3"/>
+                                <constraint firstAttribute="trailing" secondItem="VUJ-iU-ttU" secondAttribute="trailing" id="5th-F3-0AZ"/>
+                                <constraint firstItem="r0e-6S-TaN" firstAttribute="leading" secondItem="0ng-kQ-HSO" secondAttribute="leading" id="64l-dK-bdh"/>
+                                <constraint firstItem="qNI-FP-b4i" firstAttribute="top" secondItem="VUJ-iU-ttU" secondAttribute="bottom" id="7H3-2J-Xwn"/>
+                                <constraint firstAttribute="trailing" secondItem="r0e-6S-TaN" secondAttribute="trailing" id="7m1-uf-0nT"/>
+                                <constraint firstItem="VUJ-iU-ttU" firstAttribute="top" secondItem="Z4R-9z-QsZ" secondAttribute="bottom" id="KmM-TM-8ib"/>
+                                <constraint firstAttribute="trailing" secondItem="Z4R-9z-QsZ" secondAttribute="trailing" id="Zds-Wx-Xf4"/>
+                                <constraint firstItem="Z4R-9z-QsZ" firstAttribute="top" secondItem="0ng-kQ-HSO" secondAttribute="top" id="mny-m0-YIY"/>
+                                <constraint firstItem="VUJ-iU-ttU" firstAttribute="leading" secondItem="0ng-kQ-HSO" secondAttribute="leading" id="pSA-3y-YEt"/>
+                                <constraint firstItem="qNI-FP-b4i" firstAttribute="leading" secondItem="0ng-kQ-HSO" secondAttribute="leading" id="qLd-1W-rQl"/>
+                                <constraint firstAttribute="bottom" secondItem="r0e-6S-TaN" secondAttribute="bottom" id="sz3-Hw-2jb"/>
+                                <constraint firstAttribute="trailing" secondItem="qNI-FP-b4i" secondAttribute="trailing" id="t3c-96-zfs"/>
+                                <constraint firstItem="r0e-6S-TaN" firstAttribute="top" secondItem="qNI-FP-b4i" secondAttribute="bottom" id="yBI-PR-Ac2"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstItem="0ng-kQ-HSO" firstAttribute="leading" secondItem="n2Z-wh-WRK" secondAttribute="leading" constant="10" id="2UB-ER-Rxs"/>
+                        <constraint firstAttribute="trailing" secondItem="0ng-kQ-HSO" secondAttribute="trailing" constant="10" id="6wo-jM-QqD"/>
+                        <constraint firstItem="4y1-7o-AKW" firstAttribute="top" secondItem="n2Z-wh-WRK" secondAttribute="top" constant="10" id="Giw-fx-jSy"/>
+                        <constraint firstItem="0ng-kQ-HSO" firstAttribute="top" secondItem="4y1-7o-AKW" secondAttribute="bottom" constant="10" id="Tdx-BM-zog"/>
+                        <constraint firstAttribute="bottom" secondItem="0ng-kQ-HSO" secondAttribute="bottom" constant="10" id="a8u-zo-GfR"/>
+                        <constraint firstAttribute="trailing" secondItem="4y1-7o-AKW" secondAttribute="trailing" constant="10" id="j4T-GP-FWb"/>
+                        <constraint firstItem="4y1-7o-AKW" firstAttribute="leading" secondItem="n2Z-wh-WRK" secondAttribute="leading" constant="120" id="y73-vQ-amm"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lSJ-9f-d3p">
+                    <rect key="frame" x="10" y="76" width="100" height="99"/>
+                    <subviews>
+                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon.jpg" translatesAutoresizingMaskIntoConstraints="NO" id="RTX-ce-2Rf">
+                            <rect key="frame" x="0.0" y="0.0" width="100" height="99"/>
+                        </imageView>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstItem="RTX-ce-2Rf" firstAttribute="top" secondItem="lSJ-9f-d3p" secondAttribute="top" id="0xF-RO-gyX"/>
+                        <constraint firstAttribute="width" secondItem="lSJ-9f-d3p" secondAttribute="height" multiplier="1:1" constant="1" id="20T-qq-uUS"/>
+                        <constraint firstAttribute="trailing" secondItem="RTX-ce-2Rf" secondAttribute="trailing" id="Bvm-OH-pQI"/>
+                        <constraint firstAttribute="bottom" secondItem="RTX-ce-2Rf" secondAttribute="bottom" id="Csp-RG-g8y"/>
+                        <constraint firstItem="RTX-ce-2Rf" firstAttribute="leading" secondItem="lSJ-9f-d3p" secondAttribute="leading" id="hsa-yf-g3s"/>
+                        <constraint firstAttribute="width" constant="100" id="lkI-Eu-QEP"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="lSJ-9f-d3p" firstAttribute="top" secondItem="wqb-2Z-YzF" secondAttribute="top" constant="-50" id="90S-zd-2R2"/>
+                <constraint firstAttribute="trailing" secondItem="n2Z-wh-WRK" secondAttribute="trailing" id="I6k-dx-tVg"/>
+                <constraint firstAttribute="bottom" secondItem="n2Z-wh-WRK" secondAttribute="bottom" id="Rnb-Cf-WPH"/>
+                <constraint firstItem="8Ze-Ck-WDu" firstAttribute="leading" secondItem="wqb-2Z-YzF" secondAttribute="leading" id="SQF-D7-qfM"/>
+                <constraint firstAttribute="bottom" secondItem="8Ze-Ck-WDu" secondAttribute="bottom" id="WI1-Qd-nkH"/>
+                <constraint firstItem="lSJ-9f-d3p" firstAttribute="bottom" secondItem="8Ze-Ck-WDu" secondAttribute="bottom" multiplier="1.4" id="YMz-Xo-uFb"/>
+                <constraint firstItem="lSJ-9f-d3p" firstAttribute="leading" secondItem="wqb-2Z-YzF" secondAttribute="leading" constant="10" id="fCn-pV-ceb"/>
+                <constraint firstItem="8Ze-Ck-WDu" firstAttribute="top" secondItem="wqb-2Z-YzF" secondAttribute="top" id="jKQ-sb-TL8"/>
+                <constraint firstItem="n2Z-wh-WRK" firstAttribute="leading" secondItem="wqb-2Z-YzF" secondAttribute="leading" id="kCj-G4-DpZ"/>
+                <constraint firstItem="lSJ-9f-d3p" firstAttribute="top" secondItem="8Ze-Ck-WDu" secondAttribute="top" id="mwA-yw-dId"/>
+                <constraint firstItem="n2Z-wh-WRK" firstAttribute="top" secondItem="8Ze-Ck-WDu" secondAttribute="bottom" id="rcA-bb-O1j"/>
+                <constraint firstAttribute="trailing" secondItem="8Ze-Ck-WDu" secondAttribute="trailing" id="xic-L7-HTF"/>
+            </constraints>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+            <variation key="default">
+                <mask key="constraints">
+                    <exclude reference="WI1-Qd-nkH"/>
+                    <exclude reference="90S-zd-2R2"/>
+                    <exclude reference="mwA-yw-dId"/>
+                </mask>
+            </variation>
+            <connections>
+                <outlet property="descriptionLabel" destination="3fd-tv-n9a" id="cRY-m6-4Ii"/>
+                <outlet property="followerView" destination="r0e-6S-TaN" id="reK-f9-dk0"/>
+                <outlet property="locationLabel" destination="sRW-1R-vxz" id="Ca2-nG-fbB"/>
+                <outlet property="nameLabel" destination="c0E-Fa-pKh" id="Du0-Vb-R7M"/>
+                <outlet property="profileBannerURL" destination="189-Lw-sWv" id="3qH-pJ-G3u"/>
+                <outlet property="profileImageView" destination="RTX-ce-2Rf" id="LTv-Hh-aYf"/>
+                <outlet property="screenNameLabel" destination="F2V-m3-8j4" id="o4o-vA-kTd"/>
+                <outlet property="urlLabel" destination="Oxr-d7-hQe" id="SaX-Hc-bhn"/>
+            </connections>
+            <point key="canvasLocation" x="271" y="331"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="icon.jpg" width="192" height="192"/>
+    </resources>
+</document>

--- a/Tsuitta/View/User/UserDetailView.swift
+++ b/Tsuitta/View/User/UserDetailView.swift
@@ -1,0 +1,67 @@
+import UIKit
+import TwitterKit
+
+class UserDetailView: UIView, UITableViewDelegate, UITableViewDataSource  {
+    
+    private var profileData: ProfileDetailData?
+    
+    @IBOutlet weak private var tableView: UITableView!{
+        didSet{
+            self.tableView.delegate = self
+            self.tableView.dataSource = self
+            
+            self.tableView.estimatedRowHeight = 200
+            self.tableView.rowHeight = UITableViewAutomaticDimension
+        }
+    }
+    
+    private func createUserDetailInfoViewCell() -> UserDetailInfoViewCell? {
+        guard let profileData = self.profileData else {
+            return nil
+        }
+        
+        guard let cell = UINib(nibName: "UserDetailInfoViewCell", bundle: nil).instantiateWithOwner(self, options: nil).first as? UserDetailInfoViewCell else {
+            return nil
+        }
+        
+        cell.selectionStyle = .None
+        cell.setup(profileData)
+        
+        return cell
+    }
+    
+    private func createUserDetailActionViewCell() -> UserDetailActionViewCell? {
+        guard let profileData = self.profileData else {
+            return nil
+        }
+        
+        guard let cell = UINib(nibName: "UserDetailActionViewCell", bundle: nil).instantiateWithOwner(self, options: nil).first as? UserDetailActionViewCell else {
+            return nil
+        }
+        
+        cell.selectionStyle = .None
+        cell.setup(profileData)
+        
+        return cell
+    }
+    
+    func reloadProfileData(profileData: ProfileDetailData) {
+        self.profileData = profileData
+        
+        self.tableView.reloadData()
+    }
+    
+    //MARK: TableView
+    
+    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 2
+    }
+    
+    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        if indexPath.row == 0 {
+            return createUserDetailInfoViewCell() ?? UITableViewCell()
+        }
+        
+        return createUserDetailActionViewCell() ?? UITableViewCell()
+    }
+}

--- a/Tsuitta/View/User/UserDetailView.xib
+++ b/Tsuitta/View/User/UserDetailView.xib
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="UserDetailView" customModule="Tsuitta" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="FJM-ts-b3D">
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                </tableView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="FJM-ts-b3D" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="9qn-RJ-b1Z"/>
+                <constraint firstAttribute="trailing" secondItem="FJM-ts-b3D" secondAttribute="trailing" id="JZ1-i4-dPu"/>
+                <constraint firstAttribute="bottom" secondItem="FJM-ts-b3D" secondAttribute="bottom" id="KqH-HB-Bfi"/>
+                <constraint firstItem="FJM-ts-b3D" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="api-kQ-XMN"/>
+            </constraints>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+            <connections>
+                <outlet property="tableView" destination="FJM-ts-b3D" id="IKc-go-IWO"/>
+            </connections>
+        </view>
+    </objects>
+</document>


### PR DESCRIPTION
ユーザー詳細画面のレイアウト的なや～つを作成しました。

tableVIewを使ってます。
ユーザー詳細画面の構成は、一番上にユーザの情報、その下にユーザーが投稿したツイートが時系列順に並ぶので、tableViewにしています。これでツイートが何個並んでも大丈夫だね！(今はツイートに関しては特に何もしていないので表示されません。ユーザー情報部分だけです)

とりあえず、いつもの通りレイアウトをざっくり作ってそれっぽい感じにしたよ！
