### PR TITLE
ツイート投稿画面の画像選択機能を作成

### DIFF
--- a/Tsuitta.xcodeproj/project.pbxproj
+++ b/Tsuitta.xcodeproj/project.pbxproj
@@ -56,6 +56,11 @@
 		257559511C12C39D0031B6CF /* PagingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257559501C12C39D0031B6CF /* PagingController.swift */; };
 		257559541C12E3160031B6CF /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257559531C12E3160031B6CF /* LoginView.swift */; };
 		257559561C12E3250031B6CF /* LoginView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 257559551C12E3250031B6CF /* LoginView.xib */; };
+		2585B0241C8B1C1A009C08A6 /* CameraRollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2585B0231C8B1C1A009C08A6 /* CameraRollView.swift */; };
+		2585B0261C8B1C40009C08A6 /* CameraRollView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2585B0251C8B1C40009C08A6 /* CameraRollView.xib */; };
+		2585B0281C8B1C85009C08A6 /* CameraRollCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2585B0271C8B1C85009C08A6 /* CameraRollCell.xib */; };
+		2585B02A1C8B1E92009C08A6 /* CameraRollCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2585B0291C8B1E92009C08A6 /* CameraRollCell.swift */; };
+		2585B02C1C906146009C08A6 /* CameraRollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2585B02B1C906146009C08A6 /* CameraRollViewController.swift */; };
 		259DD3371C00429B00C9B7CE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259DD3361C00429B00C9B7CE /* AppDelegate.swift */; };
 		259DD33C1C00429B00C9B7CE /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 259DD33A1C00429B00C9B7CE /* Main.storyboard */; };
 		259DD33E1C00429B00C9B7CE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 259DD33D1C00429B00C9B7CE /* Assets.xcassets */; };
@@ -167,6 +172,11 @@
 		257559501C12C39D0031B6CF /* PagingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingController.swift; sourceTree = "<group>"; };
 		257559531C12E3160031B6CF /* LoginView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		257559551C12E3250031B6CF /* LoginView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LoginView.xib; sourceTree = "<group>"; };
+		2585B0231C8B1C1A009C08A6 /* CameraRollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraRollView.swift; sourceTree = "<group>"; };
+		2585B0251C8B1C40009C08A6 /* CameraRollView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CameraRollView.xib; sourceTree = "<group>"; };
+		2585B0271C8B1C85009C08A6 /* CameraRollCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CameraRollCell.xib; sourceTree = "<group>"; };
+		2585B0291C8B1E92009C08A6 /* CameraRollCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraRollCell.swift; sourceTree = "<group>"; };
+		2585B02B1C906146009C08A6 /* CameraRollViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraRollViewController.swift; sourceTree = "<group>"; };
 		259DD3331C00429A00C9B7CE /* Tsuitta.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tsuitta.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		259DD3361C00429B00C9B7CE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		259DD33B1C00429B00C9B7CE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -257,6 +267,10 @@
 			children = (
 				2524D5981C5DD48B00703B27 /* TweetComposeView.swift */,
 				2524D59A1C5DD4B500703B27 /* TweetComposeView.xib */,
+				2585B0231C8B1C1A009C08A6 /* CameraRollView.swift */,
+				2585B0251C8B1C40009C08A6 /* CameraRollView.xib */,
+				2585B0291C8B1E92009C08A6 /* CameraRollCell.swift */,
+				2585B0271C8B1C85009C08A6 /* CameraRollCell.xib */,
 			);
 			path = Compose;
 			sourceTree = "<group>";
@@ -378,6 +392,7 @@
 				259EB8301C674296002A3ED9 /* UserDetailViewController.swift */,
 				25FF51311C799D7C009C1649 /* SearchViewController.swift */,
 				25672D221C82B2A6002F3A69 /* ProfileConfigViewController.swift */,
+				2585B02B1C906146009C08A6 /* CameraRollViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -742,9 +757,11 @@
 				259DD3411C00429B00C9B7CE /* LaunchScreen.storyboard in Resources */,
 				25FF513C1C799F24009C1649 /* SearchHeaderTableViewCell.xib in Resources */,
 				25590FCF1C4258FC0024CEC3 /* sample.jpg in Resources */,
+				2585B0281C8B1C85009C08A6 /* CameraRollCell.xib in Resources */,
 				259DD33E1C00429B00C9B7CE /* Assets.xcassets in Resources */,
 				259DD33C1C00429B00C9B7CE /* Main.storyboard in Resources */,
 				25FF513A1C799EA6009C1649 /* NothingSearchResultTableViewCell.xib in Resources */,
+				2585B0261C8B1C40009C08A6 /* CameraRollView.xib in Resources */,
 				253D5E871C148E6600D59DC0 /* icon.jpg in Resources */,
 				257559561C12E3250031B6CF /* LoginView.xib in Resources */,
 				259EB8351C6EF189002A3ED9 /* UserDetailView.xib in Resources */,
@@ -796,6 +813,7 @@
 				2524D5991C5DD48B00703B27 /* TweetComposeView.swift in Sources */,
 				0652FC6D1C1D5692005006D3 /* HomeViewController.swift in Sources */,
 				0652FC7A1C1D7C65005006D3 /* UIColor+hex.swift in Sources */,
+				2585B0241C8B1C1A009C08A6 /* CameraRollView.swift in Sources */,
 				25672D301C82BE36002F3A69 /* ProfileImageConfigTableViewCell.swift in Sources */,
 				2524D5961C5DD3E500703B27 /* TweetComposeViewController.swift in Sources */,
 				259EB8311C674296002A3ED9 /* UserDetailViewController.swift in Sources */,
@@ -809,6 +827,7 @@
 				259DD3371C00429B00C9B7CE /* AppDelegate.swift in Sources */,
 				25590F991C391D660024CEC3 /* TimeLineViewController.swift in Sources */,
 				25590F9D1C40F07B0024CEC3 /* APILocator.swift in Sources */,
+				2585B02C1C906146009C08A6 /* CameraRollViewController.swift in Sources */,
 				257559541C12E3160031B6CF /* LoginView.swift in Sources */,
 				25672D381C82DF05002F3A69 /* ProfileDescriptionConfigTableViewCell.swift in Sources */,
 				259EB8391C6EF3CF002A3ED9 /* UserDetailInfoViewCell.swift in Sources */,
@@ -827,6 +846,7 @@
 				25590FCD1C424D7F0024CEC3 /* SettingAPIManager.swift in Sources */,
 				25FF513E1C799F2D009C1649 /* SearchHeaderTableViewCell.swift in Sources */,
 				2524D5881C54D36200703B27 /* TweetDetailView.swift in Sources */,
+				2585B02A1C8B1E92009C08A6 /* CameraRollCell.swift in Sources */,
 				25FF51341C799E24009C1649 /* SearchView.swift in Sources */,
 				259EB83B1C6EF3D7002A3ED9 /* UserDetailActionViewCell.swift in Sources */,
 				257559511C12C39D0031B6CF /* PagingController.swift in Sources */,

--- a/Tsuitta/Controller/CameraRollViewController.swift
+++ b/Tsuitta/Controller/CameraRollViewController.swift
@@ -1,0 +1,50 @@
+import UIKit
+
+protocol CameraRollViewControllerDelegate {
+    func addImage(photos: [UIImage], indexPaths: [NSIndexPath])
+}
+
+class CameraRollViewController: UIViewController {
+    
+    var selectedPhotoIndexPaths: [NSIndexPath]?
+    
+    var delegate: CameraRollViewControllerDelegate?
+    
+    override func loadView() {
+        super.loadView()
+        
+        if let view = UINib(nibName: "CameraRollView", bundle: nil).instantiateWithOwner(self, options: nil).first as? CameraRollView {
+            self.view = view
+        }
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let cameraRollView = self.view as! CameraRollView
+        cameraRollView.loadCollectionViewData(selectedPhotoIndexPaths)
+        
+        self.navigationController?.navigationBar.translucent = false
+        
+        let rightButton = UIBarButtonItem(title: "キャンセル", style: .Plain, target: self, action: "closeViewController")
+        let leftButton = UIBarButtonItem(title: "追加する", style: .Plain, target: self, action: "addImage")
+        
+        self.navigationItem.rightBarButtonItem = rightButton
+        self.navigationItem.leftBarButtonItem = leftButton
+    }
+    
+    @objc private func closeViewController() {
+        self.dismissViewControllerAnimated(true, completion: nil)
+    }
+    
+    @objc private func addImage() {
+        let cameraRollView = self.view as! CameraRollView
+        if let photos = cameraRollView.getSelectedPhoto(), indexPaths = cameraRollView.getSelectedPhotoIndexPaths() {
+            self.delegate?.addImage(photos, indexPaths: indexPaths)
+        }
+        self.closeViewController()
+    }
+    
+    
+    
+}

--- a/Tsuitta/View/Compose/CameraRollCell.swift
+++ b/Tsuitta/View/Compose/CameraRollCell.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+class CameraRollCell: UICollectionViewCell {
+    
+    @IBOutlet weak var imageView: UIImageView!
+    
+    @IBOutlet weak var selectedView: UIView!
+    
+    var didSelected = false {
+        didSet{
+            if self.didSelected {
+                self.selectedView.alpha = 1
+            } else {
+                self.selectedView.alpha = 0
+            }
+        }
+    }
+}

--- a/Tsuitta/View/Compose/CameraRollCell.xib
+++ b/Tsuitta/View/Compose/CameraRollCell.xib
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9532" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="RED-1K-Mxe" customClass="CameraRollCell" customModule="Tsuitta" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="100" height="91"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="100" height="91"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="1rU-1N-eLP">
+                        <rect key="frame" x="0.0" y="0.0" width="100" height="91"/>
+                    </imageView>
+                    <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cgw-hb-MJP">
+                        <rect key="frame" x="0.0" y="0.0" width="100" height="91"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                <real key="value" value="5"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                <color key="value" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                </subviews>
+                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+            </view>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="cgw-hb-MJP" secondAttribute="trailing" id="3qh-WN-brp"/>
+                <constraint firstAttribute="trailing" secondItem="1rU-1N-eLP" secondAttribute="trailing" id="7Gu-MZ-9kf"/>
+                <constraint firstAttribute="bottom" secondItem="cgw-hb-MJP" secondAttribute="bottom" constant="5" id="DIV-mn-FWG"/>
+                <constraint firstItem="1rU-1N-eLP" firstAttribute="top" secondItem="RED-1K-Mxe" secondAttribute="top" id="P8F-Zr-cJp"/>
+                <constraint firstItem="cgw-hb-MJP" firstAttribute="top" secondItem="RED-1K-Mxe" secondAttribute="top" id="Q0I-EC-gAm"/>
+                <constraint firstItem="cgw-hb-MJP" firstAttribute="leading" secondItem="RED-1K-Mxe" secondAttribute="leading" constant="5" id="TWG-3Z-imK"/>
+                <constraint firstAttribute="bottom" secondItem="1rU-1N-eLP" secondAttribute="bottom" id="fqq-ep-jtM"/>
+                <constraint firstAttribute="trailing" secondItem="cgw-hb-MJP" secondAttribute="trailing" constant="5" id="rUf-nU-WNy"/>
+                <constraint firstItem="cgw-hb-MJP" firstAttribute="leading" secondItem="RED-1K-Mxe" secondAttribute="leading" id="tkV-Mg-IE1"/>
+                <constraint firstItem="1rU-1N-eLP" firstAttribute="leading" secondItem="RED-1K-Mxe" secondAttribute="leading" id="wp9-c5-xrN"/>
+                <constraint firstItem="cgw-hb-MJP" firstAttribute="top" secondItem="RED-1K-Mxe" secondAttribute="top" constant="5" id="xNE-QK-2fD"/>
+                <constraint firstAttribute="bottom" secondItem="cgw-hb-MJP" secondAttribute="bottom" id="zAt-q8-LYO"/>
+            </constraints>
+            <size key="customSize" width="100" height="91"/>
+            <variation key="default">
+                <mask key="constraints">
+                    <exclude reference="DIV-mn-FWG"/>
+                    <exclude reference="TWG-3Z-imK"/>
+                    <exclude reference="rUf-nU-WNy"/>
+                    <exclude reference="xNE-QK-2fD"/>
+                </mask>
+            </variation>
+            <connections>
+                <outlet property="imageView" destination="1rU-1N-eLP" id="cCp-CT-s61"/>
+                <outlet property="selectedView" destination="cgw-hb-MJP" id="YL9-RR-3bc"/>
+            </connections>
+            <point key="canvasLocation" x="254" y="276.5"/>
+        </collectionViewCell>
+    </objects>
+</document>

--- a/Tsuitta/View/Compose/CameraRollView.swift
+++ b/Tsuitta/View/Compose/CameraRollView.swift
@@ -1,0 +1,180 @@
+import UIKit
+import Photos
+
+class SelectedPhotoIndexPaths {
+    
+    private var selectedPhotoIndexPaths = [NSIndexPath]()
+    
+    private let maxSelectPhotoNumber = 4
+    
+    init(indexPaths: [NSIndexPath]?) {
+        indexPaths?.forEach { indexPath in
+            self.addIndexPath(indexPath)
+        }
+    }
+    
+    func addIndexPath(indexPath: NSIndexPath) -> NSIndexPath? {
+        // 同じIndexPathがすでにあったら削除
+        if let index = self.selectedPhotoIndexPaths.indexOf(indexPath) {
+            return self.selectedPhotoIndexPaths.removeAtIndex(index)
+        }
+        
+        var index: NSIndexPath?
+        // 規定数を超えたら先頭を削除
+        if self.selectedPhotoIndexPaths.count >= self.maxSelectPhotoNumber {
+            index = self.selectedPhotoIndexPaths.removeFirst()
+        }
+        
+        self.selectedPhotoIndexPaths.append(indexPath)
+        return index
+    }
+    
+    func getIndexPaths() -> [NSIndexPath] {
+        return self.selectedPhotoIndexPaths
+    }
+    
+    func isSelected(indexPath: NSIndexPath) -> Bool {
+        for ip in self.selectedPhotoIndexPaths {
+            print("ip: section:\(ip.section) row:\(ip.row)  indexPath: section:\(indexPath.section) row:\(indexPath.row)")
+            if ip.row == indexPath.row && ip.section == indexPath.section {
+                return true
+            }
+        }
+        
+        return false
+        //       return self.selectedPhotoIndexPaths.contains(indexPath)
+        //        indexPath.
+    }
+}
+
+class CameraRollView: UIView, UICollectionViewDelegate, UICollectionViewDataSource {
+    
+    private let cellIdentifier = "CameraRollCell"
+    
+    private var photos = [UIImage]()
+    
+    private var selectedPhotoIndexPaths: SelectedPhotoIndexPaths?
+    
+    @IBOutlet weak var collectionView: UICollectionView! {
+        didSet{
+            let layout = UICollectionViewFlowLayout()
+            let cellLegth = self.bounds.width / 3
+            layout.itemSize = CGSizeMake(cellLegth, cellLegth)
+            layout.sectionInset = UIEdgeInsetsZero
+            layout.headerReferenceSize = CGSizeZero
+            layout.footerReferenceSize = CGSizeZero
+            layout.minimumInteritemSpacing = 0.0
+            layout.minimumLineSpacing = 1.0
+            
+            self.collectionView.collectionViewLayout = layout
+            
+            self.collectionView.delegate = self
+            self.collectionView.dataSource = self
+            self.collectionView.registerNib(UINib(nibName: "CameraRollCell", bundle: nil), forCellWithReuseIdentifier: cellIdentifier)
+        }
+    }
+    
+    func loadCollectionViewData(selectedPhotoIndexPaths: [NSIndexPath]?) {
+        var photoAssets = [PHAsset]()
+        
+        // ソート条件を指定
+        let options = PHFetchOptions()
+        options.sortDescriptors = [
+            NSSortDescriptor(key: "creationDate", ascending: true)
+        ]
+        
+        // 画像をすべて取得
+        let assets: PHFetchResult = PHAsset.fetchAssetsWithMediaType(.Image, options: options)
+        assets.enumerateObjectsUsingBlock { (asset, index, stop) -> Void in
+            photoAssets.append(asset as! PHAsset)
+        }
+        
+        let manager: PHImageManager = PHImageManager()
+        let minImageLength = floor(self.bounds.width / 3)
+        
+        photoAssets.forEach { photo in
+            
+            let width: CGFloat = CGFloat(photo.pixelWidth)
+            let height: CGFloat = CGFloat(photo.pixelHeight)
+            let imageWidth: CGFloat
+            let imageHeight: CGFloat
+            if width >= height {
+                imageHeight = minImageLength
+                imageWidth = floor(minImageLength * width / height)
+            } else {
+                imageWidth = minImageLength
+                imageHeight = floor(minImageLength / width * height)
+            }
+            
+            manager.requestImageForAsset(photo,
+                targetSize: CGSizeMake(imageWidth, imageHeight),
+                contentMode: .AspectFill,
+                options: nil) { (image, info) -> Void in
+                    guard let i = info, b = i[PHImageResultIsDegradedKey]?.boolValue where b else{
+                        return
+                    }
+                    if let i = image {
+                        self.async {
+                            self.photos.append(i)
+                        }
+                    }
+            }
+        }
+        
+        dispatch_async(dispatch_get_main_queue()) {
+            self.collectionView.reloadData()
+        }
+        
+        self.selectedPhotoIndexPaths = SelectedPhotoIndexPaths(indexPaths: selectedPhotoIndexPaths)
+    }
+    
+    /*
+    Cellが選択された際に呼び出される
+    */
+    func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
+        let cell = collectionView.cellForItemAtIndexPath(indexPath) as! CameraRollCell
+        cell.didSelected = !cell.didSelected
+        if let index = self.selectedPhotoIndexPaths?.addIndexPath(indexPath) {
+            let cell = collectionView.cellForItemAtIndexPath(index) as! CameraRollCell
+            cell.didSelected = false
+        }
+    }
+    
+    /*
+    Cellの総数を返す
+    */
+    func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return self.photos.count
+    }
+    
+    /*
+    Cellに値を設定する
+    */
+    func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
+        
+        let cell = collectionView.dequeueReusableCellWithReuseIdentifier(cellIdentifier,
+            forIndexPath: indexPath) as! CameraRollCell
+        
+        cell.imageView.image = self.photos[indexPath.row]
+        
+        cell.didSelected = self.selectedPhotoIndexPaths!.isSelected(indexPath)
+        
+        return cell
+    }
+    
+    private func async(callback: () -> Void) {
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+            callback()
+        }
+    }
+    
+    func getSelectedPhoto() -> [UIImage]? {
+        guard let indexPaths = self.selectedPhotoIndexPaths?.getIndexPaths() else { return nil }
+        return indexPaths.map{ self.photos[$0.row] }
+    }
+    
+    func getSelectedPhotoIndexPaths() -> [NSIndexPath]? {
+        return self.selectedPhotoIndexPaths?.getIndexPaths()
+    }
+    
+}

--- a/Tsuitta/View/Compose/CameraRollView.xib
+++ b/Tsuitta/View/Compose/CameraRollView.xib
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9532" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="CameraRollView" customModule="Tsuitta" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="qOt-d0-edM">
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                    <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="LWN-sf-nvI">
+                        <size key="itemSize" width="50" height="50"/>
+                        <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                        <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                        <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                    </collectionViewFlowLayout>
+                </collectionView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="qOt-d0-edM" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="8mK-D9-pc1"/>
+                <constraint firstItem="qOt-d0-edM" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="DtA-ou-OG8"/>
+                <constraint firstAttribute="trailing" secondItem="qOt-d0-edM" secondAttribute="trailing" id="FQR-is-H0S"/>
+                <constraint firstAttribute="bottom" secondItem="qOt-d0-edM" secondAttribute="bottom" id="hgv-R5-xlc"/>
+            </constraints>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+            <connections>
+                <outlet property="collectionView" destination="qOt-d0-edM" id="9Uq-Mr-u6X"/>
+            </connections>
+        </view>
+    </objects>
+</document>


### PR DESCRIPTION
ツイート投稿画面の画像選択ViewControllerを作成
・端末のカメラロールの全画像を日付順に表示します。
・セルをタップすると選択状態になり、再度タップすると選択状態が解除されます。
・同時に選択できるのは４つまでです。５つ目をタップすると１つ目に選択したものの選択状態が解除されます。
・

すいません。マージ小分けにするの忘れていました。

CameraRollViewController: カメラロールの画像を表示するVC
CameraRollView: カメラロールの画像を表示するView
CameraRollCell: CameraRollViewのcollectionViewで使用するCell
